### PR TITLE
Fix sidebar tooltip accessible name handling

### DIFF
--- a/GTKUI/sidebar.py
+++ b/GTKUI/sidebar.py
@@ -100,9 +100,7 @@ class Sidebar(Gtk.Window):
         icon.get_style_context().add_class("icon")
         if tooltip:
             icon.set_tooltip_text(tooltip)
-            accessible = icon.get_accessible()
-            if accessible:
-                accessible.set_name(tooltip)
+            icon.set_accessible_name(tooltip)
         gesture = Gtk.GestureClick.new()
         gesture.connect("pressed", lambda gesture, n_press, x, y: callback())
         icon.add_controller(gesture)


### PR DESCRIPTION
## Summary
- simplify tooltip accessibility handling in Sidebar.create_icon by setting the accessible name directly on the widget

## Testing
- python -m py_compile GTKUI/sidebar.py

------
https://chatgpt.com/codex/tasks/task_e_68cae65d3d988322a4246f36e47a3231