### PR TITLE
Guard sidebar icon accessibility on GTK 4

### DIFF
--- a/GTKUI/sidebar.py
+++ b/GTKUI/sidebar.py
@@ -100,7 +100,9 @@ class Sidebar(Gtk.Window):
         icon.get_style_context().add_class("icon")
         if tooltip:
             icon.set_tooltip_text(tooltip)
-            icon.set_accessible_name(tooltip)
+            accessible = icon.get_accessible()
+            if accessible is not None:
+                accessible.update_property(Gtk.AccessibleProperty.LABEL, tooltip)
         gesture = Gtk.GestureClick.new()
         gesture.connect("pressed", lambda gesture, n_press, x, y: callback())
         icon.add_controller(gesture)


### PR DESCRIPTION
## Summary
- replace the Gtk.Picture accessible name call with a Gtk.Accessible property update when a tooltip is provided
- maintain tooltip behavior while avoiding GTK 4 AttributeError during sidebar startup

## Testing
- python -m py_compile GTKUI/sidebar.py

------
https://chatgpt.com/codex/tasks/task_e_68cae795af348322a0980e3333d12a6b