### PR TITLE
Wrap persona and provider menus in scrolled containers

### DIFF
--- a/GTKUI/Persona_manager/persona_management.py
+++ b/GTKUI/Persona_manager/persona_management.py
@@ -73,23 +73,27 @@ class PersonaManagement:
         self.persona_window.get_style_context().add_class("sidebar")
         self.persona_window.set_tooltip_text("Choose a persona or open its settings.")
 
-        # Container
+        # Container inside a scrolled window so long persona lists remain usable
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_propagate_natural_height(True)
+        scroll.set_hexpand(True)
+        scroll.set_vexpand(True)
+        self.persona_window.set_child(scroll)
+
         outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
         outer.set_margin_top(10)
         outer.set_margin_bottom(10)
         outer.set_margin_start(10)
         outer.set_margin_end(10)
-        self.persona_window.set_child(outer)
-
-        # Scrollable list area
-        scroll = Gtk.ScrolledWindow()
-        scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        outer.append(scroll)
+        outer.set_valign(Gtk.Align.START)
+        scroll.set_child(outer)
 
         list_box = Gtk.ListBox()
         list_box.set_selection_mode(Gtk.SelectionMode.NONE)
         list_box.set_tooltip_text("Click a row to select the persona; use the gear to edit its settings.")
-        scroll.set_child(list_box)
+        list_box.set_valign(Gtk.Align.START)
+        outer.append(list_box)
 
         # Retrieve persona names from ATLAS
         persona_names = self.ATLAS.get_persona_names() or []
@@ -142,6 +146,7 @@ class PersonaManagement:
         # Hint footer
         hint = Gtk.Label(label="Tip: double-click a row to select.")
         hint.set_tooltip_text("You can also use arrow keys to move and Enter to activate.")
+        hint.set_margin_top(6)
         outer.append(hint)
 
         # Double-click behavior on rows (optional)

--- a/GTKUI/Provider_manager/provider_management.py
+++ b/GTKUI/Provider_manager/provider_management.py
@@ -90,9 +90,17 @@ class ProviderManagement:
         self.provider_window.set_modal(True)
         self.provider_window.set_tooltip_text("Choose a default LLM provider or open its settings.")
 
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_propagate_natural_height(True)
+        scrolled.set_hexpand(True)
+        scrolled.set_vexpand(True)
+        self.provider_window.set_child(scrolled)
+
         box = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=10, margin=10)
         box.set_tooltip_text("Available providers registered in ATLAS.")
-        self.provider_window.set_child(box)
+        box.set_valign(Gtk.Align.START)
+        scrolled.set_child(box)
 
         provider_names = self.ATLAS.get_available_providers()
 


### PR DESCRIPTION
## Summary
- embed the persona selection layout in a scrolled window so long lists remain usable without losing existing spacing
- wrap the provider selection menu in a scrolled container that grows with the dialog to preserve gesture behavior and margins

## Testing
- python -m compileall GTKUI/Persona_manager/persona_management.py GTKUI/Provider_manager/provider_management.py

------
https://chatgpt.com/codex/tasks/task_e_68cb6c1e5b388322b9320cea1b4f467d