### PR TITLE
Handle TTS within chat session flow

### DIFF
--- a/GTKUI/Chat/chat_page.py
+++ b/GTKUI/Chat/chat_page.py
@@ -324,23 +324,17 @@ class ChatPage(Gtk.Window):
         """
         Processes the model's response asynchronously in a separate thread,
         then schedules the UI update to add the assistant's message bubble.
-        Also triggers TTS if enabled.
+        The backend handles any text-to-speech responsibilities.
         """
         loop = asyncio.new_event_loop()
         try:
             asyncio.set_event_loop(loop)
             response = loop.run_until_complete(self.chat_session.send_message(message))
 
-            # Trigger TTS for the response if enabled.
-            try:
-                loop.run_until_complete(self.ATLAS.speech_manager.text_to_speech(response))
-            except Exception as tts_err:
-                logger.warning(f"TTS error (continuing): {tts_err}")
-
             persona_name = self.ATLAS.persona_manager.current_persona.get('name', 'Assistant')
             GLib.idle_add(self.add_message_bubble, persona_name, response)
         except Exception as e:
-            logger.error(f"Error in handle_model_response: {e}")
+            logger.error(f"Error retrieving model response: {e}")
             GLib.idle_add(self.add_message_bubble, "Assistant", f"Error: {e}")
         finally:
             try:

--- a/modules/Chat/chat_session.py
+++ b/modules/Chat/chat_session.py
@@ -38,12 +38,15 @@ class ChatSession:
                 model=self.current_model,
                 stream=False
             )
-            self.conversation_history.append({"role": "assistant", "content": response})
-            self.messages_since_last_reminder += 1
-            return response
         except Exception as e:
-            self.ATLAS.logger.error(f"Error generating response: {e}")
-            raise e
+            self.ATLAS.logger.error(f"Error generating response: {e}", exc_info=True)
+            raise
+
+        await self.ATLAS.maybe_text_to_speech(response)
+
+        self.conversation_history.append({"role": "assistant", "content": response})
+        self.messages_since_last_reminder += 1
+        return response
 
     def switch_persona(self, new_persona_prompt: str):
         self.current_persona_prompt = new_persona_prompt


### PR DESCRIPTION
## Summary
- centralize text-to-speech handling in a new `ATLAS.maybe_text_to_speech` helper used by both chat session and direct generation paths
- update the chat session coroutine to await TTS before returning so backend errors surface consistently
- remove UI-level TTS triggering so the frontend simply renders the returned response text

## Testing
- python -m compileall ATLAS/ATLAS.py modules/Chat/chat_session.py GTKUI/Chat/chat_page.py

------
https://chatgpt.com/codex/tasks/task_e_68cdf57b731c8322b02d1930b27a2968