### PR TITLE
Add managed speech configuration setters and tests

### DIFF
--- a/GTKUI/Provider_manager/Settings/HF_settings.py
+++ b/GTKUI/Provider_manager/Settings/HF_settings.py
@@ -1140,11 +1140,14 @@ class HuggingFaceSettingsWindow(Gtk.Window):
             self.show_message("Error", "Token cannot be empty.", Gtk.MessageType.ERROR)
             return
         try:
-            if hasattr(self.config_manager, "update_api_key"):
-                self.config_manager.update_api_key("HuggingFace", token)
+            if hasattr(self.config_manager, "set_hf_token"):
+                self.config_manager.set_hf_token(token)
             else:
-                self.config_manager.config["HUGGINGFACE_API_KEY"] = token
-            os.environ["HUGGINGFACE_API_KEY"] = token
+                if hasattr(self.config_manager, "update_api_key"):
+                    self.config_manager.update_api_key("HuggingFace", token)
+                else:
+                    self.config_manager.config["HUGGINGFACE_API_KEY"] = token
+                os.environ["HUGGINGFACE_API_KEY"] = token
             self.show_message("Success", "Hugging Face token saved.", Gtk.MessageType.INFO)
             # Do not reveal; switch back to placeholder
             self.hf_token_entry.set_text("")

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,125 @@
+import os
+import sys
+import types
+
+import pytest
+
+if "yaml" not in sys.modules:
+    yaml_module = types.ModuleType("yaml")
+    yaml_module.safe_load = lambda *args, **kwargs: {}
+    yaml_module.dump = lambda *args, **kwargs: None
+    sys.modules["yaml"] = yaml_module
+
+if "dotenv" not in sys.modules:
+    dotenv_module = types.ModuleType("dotenv")
+    dotenv_module.load_dotenv = lambda *args, **kwargs: None
+    dotenv_module.set_key = lambda *args, **kwargs: None
+    dotenv_module.find_dotenv = lambda *args, **kwargs: ""
+    sys.modules["dotenv"] = dotenv_module
+
+import ATLAS.config as config_module
+from ATLAS.config import ConfigManager
+
+
+@pytest.fixture
+def config_manager(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "initial-key")
+    monkeypatch.setenv("DEFAULT_PROVIDER", "OpenAI")
+    monkeypatch.setenv("DEFAULT_MODEL", "gpt-4o")
+
+    recorded = {}
+
+    def fake_set_key(path, key, value):
+        recorded[(path, key)] = value
+
+    monkeypatch.setattr(config_module, "set_key", fake_set_key)
+    monkeypatch.setattr(config_module, "find_dotenv", lambda: str(env_file))
+    monkeypatch.setattr(config_module, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        ConfigManager,
+        "_load_env_config",
+        lambda self: {
+            "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY"),
+            "DEFAULT_PROVIDER": os.getenv("DEFAULT_PROVIDER", "OpenAI"),
+            "DEFAULT_MODEL": os.getenv("DEFAULT_MODEL", "gpt-4o"),
+            "MISTRAL_API_KEY": None,
+            "HUGGINGFACE_API_KEY": None,
+            "GOOGLE_API_KEY": None,
+            "ANTHROPIC_API_KEY": None,
+            "GROK_API_KEY": None,
+            "APP_ROOT": tmp_path.as_posix(),
+        },
+    )
+    monkeypatch.setattr(ConfigManager, "_load_yaml_config", lambda self: {})
+
+    manager = ConfigManager()
+    manager._recorded_set_key = recorded
+    manager._env_path = str(env_file)
+    return manager
+
+
+def test_set_google_credentials_updates_state(config_manager):
+    config_manager.set_google_credentials("/tmp/creds.json")
+
+    assert config_manager.config["GOOGLE_APPLICATION_CREDENTIALS"] == "/tmp/creds.json"
+    assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == "/tmp/creds.json"
+    assert (
+        config_manager._recorded_set_key[(config_manager._env_path, "GOOGLE_APPLICATION_CREDENTIALS")]
+        == "/tmp/creds.json"
+    )
+
+
+def test_set_google_credentials_failure_rolls_back(config_manager, monkeypatch):
+    def fail(*args, **kwargs):
+        raise RuntimeError("write error")
+
+    monkeypatch.setattr(config_module, "set_key", fail)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+    with pytest.raises(RuntimeError):
+        config_manager.set_google_credentials("/tmp/new.json")
+
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in config_manager.config
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ
+
+
+def test_set_openai_speech_config_updates_values(config_manager):
+    config_manager.set_openai_speech_config(
+        api_key="fresh-key",
+        stt_provider="GPT-4o STT",
+        tts_provider="GPT-4o Mini TTS",
+        language="en",
+        task="transcribe",
+        initial_prompt="hello",
+    )
+
+    assert config_manager.config["OPENAI_API_KEY"] == "fresh-key"
+    assert config_manager.config["OPENAI_STT_PROVIDER"] == "GPT-4o STT"
+    assert config_manager.config["OPENAI_TTS_PROVIDER"] == "GPT-4o Mini TTS"
+    assert config_manager.config["OPENAI_LANGUAGE"] == "en"
+    assert config_manager.config["OPENAI_TASK"] == "transcribe"
+    assert config_manager.config["OPENAI_INITIAL_PROMPT"] == "hello"
+    assert os.environ["OPENAI_API_KEY"] == "fresh-key"
+    assert (
+        config_manager._recorded_set_key[(config_manager._env_path, "OPENAI_API_KEY")]
+        == "fresh-key"
+    )
+
+
+def test_set_openai_speech_config_rejects_empty_key(config_manager):
+    with pytest.raises(ValueError):
+        config_manager.set_openai_speech_config(api_key="")
+
+
+def test_set_hf_token_updates_state(config_manager):
+    config_manager.set_hf_token("hf-token")
+
+    assert config_manager.config["HUGGINGFACE_API_KEY"] == "hf-token"
+    assert os.environ["HUGGINGFACE_API_KEY"] == "hf-token"
+    assert (
+        config_manager._recorded_set_key[(config_manager._env_path, "HUGGINGFACE_API_KEY")]
+        == "hf-token"
+    )


### PR DESCRIPTION
## Summary
- add persistence helpers in `ConfigManager` for OpenAI speech, Google credentials, and Hugging Face tokens
- update `SpeechManager` to reconfigure providers through dedicated setters and refresh logic
- refactor GTK speech settings UI to use the new APIs and surface status messages
- add test coverage for configuration persistence, provider re-registration, and failure handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cef902bad48322b90294289c2f64cc