### PR TITLE
Handle missing HuggingFace models gracefully

### DIFF
--- a/GTKUI/Provider_manager/provider_management.py
+++ b/GTKUI/Provider_manager/provider_management.py
@@ -393,7 +393,10 @@ class ProviderManagement:
             buttons=Gtk.ButtonsType.OK,
             text="Error",
         )
-        dialog.format_secondary_text(message)
+        if hasattr(dialog, "set_secondary_text"):
+            dialog.set_secondary_text(message)
+        else:  # Fallback for API variations
+            dialog.props.secondary_text = message
         dialog.connect("response", lambda dialog, response: dialog.destroy())
         dialog.set_tooltip_text("Close to dismiss this error message.")
         dialog.present()
@@ -412,7 +415,10 @@ class ProviderManagement:
             buttons=Gtk.ButtonsType.OK,
             text="Information",
         )
-        dialog.format_secondary_text(message)
+        if hasattr(dialog, "set_secondary_text"):
+            dialog.set_secondary_text(message)
+        else:  # Fallback for API variations
+            dialog.props.secondary_text = message
         dialog.connect("response", lambda dialog, response: dialog.destroy())
         dialog.set_tooltip_text("Close to continue.")
         dialog.present()


### PR DESCRIPTION
## Summary
- avoid raising an exception when HuggingFace has no configured default model and keep the provider selectable
- reset the current model when switching to HuggingFace without a default and keep the model manager in sync
- update GTK error/info dialogs to use the GTK 4 API for secondary text to prevent runtime attribute errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf0e40ec6483228db650505d4af399