### PR TITLE
Add speech provider accessor helpers and update UI

### DIFF
--- a/GTKUI/Settings/Speech/speech_settings.py
+++ b/GTKUI/Settings/Speech/speech_settings.py
@@ -246,10 +246,11 @@ class SpeechSettings(Gtk.Window):
         tts_provider_label.set_tooltip_text("Choose the service used for TTS by default.")
         self.default_tts_combo = Gtk.ComboBoxText()
         self.default_tts_combo.set_tooltip_text("Select the default TTS service.")
-        for key in self.ATLAS.speech_manager.tts_services.keys():
+        tts_provider_names = self.ATLAS.speech_manager.get_tts_provider_names()
+        for key in tts_provider_names:
             self.default_tts_combo.append_text(key)
-        if current_tts_provider:
-            index = list(self.ATLAS.speech_manager.tts_services.keys()).index(current_tts_provider)
+        if current_tts_provider and current_tts_provider in tts_provider_names:
+            index = tts_provider_names.index(current_tts_provider)
             self.default_tts_combo.set_active(index)
         hbox_tts_provider.append(tts_provider_label)
         hbox_tts_provider.append(self.default_tts_combo)
@@ -273,10 +274,11 @@ class SpeechSettings(Gtk.Window):
         stt_provider_label.set_tooltip_text("Choose the service used for STT by default.")
         self.default_stt_combo = Gtk.ComboBoxText()
         self.default_stt_combo.set_tooltip_text("Select the default STT service.")
-        for key in self.ATLAS.speech_manager.stt_services.keys():
+        stt_provider_names = self.ATLAS.speech_manager.get_stt_provider_names()
+        for key in stt_provider_names:
             self.default_stt_combo.append_text(key)
-        if default_stt:
-            index = list(self.ATLAS.speech_manager.stt_services.keys()).index(default_stt)
+        if default_stt and default_stt in stt_provider_names:
+            index = stt_provider_names.index(default_stt)
             self.default_stt_combo.set_active(index)
         hbox_stt_provider.append(stt_provider_label)
         hbox_stt_provider.append(self.default_stt_combo)

--- a/modules/Speech_Services/speech_manager.py
+++ b/modules/Speech_Services/speech_manager.py
@@ -448,6 +448,22 @@ class SpeechManager:
         self.active_tts = tts
         logger.info(f"Default TTS provider set to '{provider}'.")
 
+    def get_tts_provider_names(self) -> Tuple[str, ...]:
+        """Return the registered TTS provider keys in insertion order."""
+
+        return tuple(self.tts_services.keys())
+
+    def get_default_tts_provider_index(self) -> Optional[int]:
+        """Return the index of the default TTS provider within the provider list."""
+
+        provider = self.get_default_tts_provider()
+        if not provider:
+            return None
+        try:
+            return self.get_tts_provider_names().index(provider)
+        except ValueError:
+            return None
+
     def set_default_speech_providers(self, tts_provider: Optional[str] = None, stt_provider: Optional[str] = None):
         """Update the default TTS and/or STT providers in a single call."""
 
@@ -797,6 +813,22 @@ class SpeechManager:
         self._active_stt_key = provider
         self.active_stt = stt
         logger.info(f"Default STT provider set to '{provider}'.")
+
+    def get_stt_provider_names(self) -> Tuple[str, ...]:
+        """Return the registered STT provider keys in insertion order."""
+
+        return tuple(self.stt_services.keys())
+
+    def get_default_stt_provider_index(self) -> Optional[int]:
+        """Return the index of the default STT provider within the provider list."""
+
+        provider = self.get_default_stt_provider()
+        if not provider:
+            return None
+        try:
+            return self.get_stt_provider_names().index(provider)
+        except ValueError:
+            return None
 
     def _resolve_audio_reference(self, provider: Optional[str], stt_instance: Any) -> Optional[str]:
         """Infer the audio reference produced by an STT provider after recording."""

--- a/tests/test_speech_manager.py
+++ b/tests/test_speech_manager.py
@@ -267,6 +267,56 @@ def speech_manager():
     return _SpeechManagerForTest(_DummyConfig())
 
 
+def test_get_tts_provider_names_returns_ordered_copy(speech_manager):
+    speech_manager.tts_services["alpha"] = object()
+    speech_manager.tts_services["beta"] = object()
+
+    names = speech_manager.get_tts_provider_names()
+
+    assert names == ("alpha", "beta")
+
+    speech_manager.tts_services["gamma"] = object()
+
+    assert names == ("alpha", "beta")
+
+
+def test_get_stt_provider_names_returns_ordered_copy(speech_manager):
+    speech_manager.stt_services["delta"] = object()
+    speech_manager.stt_services["epsilon"] = object()
+
+    names = speech_manager.get_stt_provider_names()
+
+    assert names == ("delta", "epsilon")
+
+    speech_manager.stt_services["zeta"] = object()
+
+    assert names == ("delta", "epsilon")
+
+
+def test_get_default_tts_provider_index_tracks_provider(speech_manager):
+    speech_manager.tts_services["one"] = object()
+    speech_manager.tts_services["two"] = object()
+    speech_manager.set_default_tts_provider("two")
+
+    assert speech_manager.get_default_tts_provider_index() == 1
+
+    speech_manager.remove_tts_provider("two")
+
+    assert speech_manager.get_default_tts_provider_index() is None
+
+
+def test_get_default_stt_provider_index_tracks_provider(speech_manager):
+    speech_manager.stt_services["uno"] = object()
+    speech_manager.stt_services["dos"] = object()
+    speech_manager.set_default_stt_provider("dos")
+
+    assert speech_manager.get_default_stt_provider_index() == 1
+
+    speech_manager.remove_stt_provider("dos")
+
+    assert speech_manager.get_default_stt_provider_index() is None
+
+
 def test_summary_prefers_get_current_voice_dict(speech_manager):
     class Provider:
         def get_current_voice(self):


### PR DESCRIPTION
## Summary
- add accessor helpers to expose ordered TTS/STT provider keys from the speech manager
- refactor the GTK speech settings UI to consume the new accessors instead of direct dict access
- extend the speech manager unit tests to cover the new helper behaviour

## Testing
- pytest tests/test_speech_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68cf139711a0832296d4d8456fff555b