### PR TITLE
Add provider-managed Hugging Face token validation

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -1,6 +1,6 @@
 # ATLAS/ATLAS.py
 
-from typing import List, Dict, Union, AsyncIterator
+from typing import List, Dict, Union, AsyncIterator, Optional
 from ATLAS.config import ConfigManager
 from modules.logging.logger import setup_logger
 from ATLAS.provider_manager import ProviderManager
@@ -98,7 +98,12 @@ class ATLAS:
             List[str]: A list of provider names.
         """
         return self.provider_manager.get_available_providers()
-    
+
+    async def test_huggingface_token(self, token: Optional[str] = None) -> Dict[str, Any]:
+        """Validate a HuggingFace API token via the provider manager."""
+
+        return await self.provider_manager.test_huggingface_token(token)
+
     async def set_current_provider(self, provider: str):
         """
         Asynchronously set the current provider in the ProviderManager.


### PR DESCRIPTION
## Summary
- add an async ProviderManager helper that validates Hugging Face tokens and reuses stored credentials
- expose the helper via the ATLAS facade and update the GTK settings window to call it asynchronously
- extend provider manager tests with stubbed HfApi coverage for token validation success and failure

## Testing
- pytest tests/test_provider_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68cf213afe7883228f368dad7b38b4ed