### PR TITLE
Import Any in ATLAS typing module

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -1,6 +1,6 @@
 # ATLAS/ATLAS.py
 
-from typing import List, Dict, Union, AsyncIterator, Optional
+from typing import List, Dict, Union, AsyncIterator, Optional, Any
 from ATLAS.config import ConfigManager
 from modules.logging.logger import setup_logger
 from ATLAS.provider_manager import ProviderManager


### PR DESCRIPTION
## Summary
- include Any in ATLAS module typing imports to satisfy type hints

## Testing
- python - <<'PY'
from ATLAS.ATLAS import ATLAS
print('Imported ATLAS class:', ATLAS)
PY (fails: ModuleNotFoundError: No module named 'torch')

------
https://chatgpt.com/codex/tasks/task_e_68cf2335472c832285d93c3416e673b2