### PR TITLE
Add helper to resolve active TTS provider

### DIFF
--- a/GTKUI/Settings/Speech/speech_settings.py
+++ b/GTKUI/Settings/Speech/speech_settings.py
@@ -403,11 +403,12 @@ class SpeechSettings(Gtk.Window):
             )
             return
 
+        speech_manager = self.ATLAS.speech_manager
         selected_voice_name = self.voice_combo.get_active_text()
-        provider_key = self.ATLAS.speech_manager.get_default_tts_provider()
-        if not provider_key or provider_key not in getattr(self.ATLAS.speech_manager, 'tts_services', {}):
-            provider_key = 'eleven_labs'
-        voices = self.ATLAS.speech_manager.get_tts_voices(provider_key) or []
+        provider_key = speech_manager.resolve_tts_provider(
+            speech_manager.get_default_tts_provider()
+        )
+        voices = speech_manager.get_tts_voices(provider_key) or [] if provider_key else []
         selected_voice = None
         if selected_voice_name:
             selected_voice = next(
@@ -415,8 +416,8 @@ class SpeechSettings(Gtk.Window):
                 None,
             )
 
-        if selected_voice:
-            self.ATLAS.speech_manager.set_tts_voice(selected_voice, provider_key)
+        if selected_voice and provider_key:
+            speech_manager.set_tts_voice(selected_voice, provider_key)
 
         # Refresh the combo box to reflect any updated voice list.
         if hasattr(self.voice_combo, "remove_all"):

--- a/modules/Speech_Services/speech_manager.py
+++ b/modules/Speech_Services/speech_manager.py
@@ -527,6 +527,19 @@ class SpeechManager:
 
         return tuple(self.tts_services.keys())
 
+    def resolve_tts_provider(self, preferred: Optional[str]) -> Optional[str]:
+        """Resolve a TTS provider from a preferred key with sensible fallbacks."""
+
+        providers = self.get_tts_provider_names()
+        if preferred and preferred in providers:
+            return preferred
+
+        for fallback in ("eleven_labs",):
+            if fallback in providers:
+                return fallback
+
+        return providers[0] if providers else None
+
     def get_default_tts_provider_index(self) -> Optional[int]:
         """Return the index of the default TTS provider within the provider list."""
 

--- a/tests/test_speech_manager.py
+++ b/tests/test_speech_manager.py
@@ -280,6 +280,37 @@ def test_get_tts_provider_names_returns_ordered_copy(speech_manager):
     assert names == ("alpha", "beta")
 
 
+def test_resolve_tts_provider_prefers_registered_choice(speech_manager):
+    speech_manager.tts_services["eleven_labs"] = object()
+    speech_manager.tts_services["custom"] = object()
+
+    resolved = speech_manager.resolve_tts_provider("custom")
+
+    assert resolved == "custom"
+
+
+def test_resolve_tts_provider_falls_back_to_eleven_labs(speech_manager):
+    speech_manager.tts_services["eleven_labs"] = object()
+    speech_manager.tts_services["google"] = object()
+
+    resolved = speech_manager.resolve_tts_provider("missing")
+
+    assert resolved == "eleven_labs"
+
+
+def test_resolve_tts_provider_returns_first_available_when_no_fallback(speech_manager):
+    speech_manager.tts_services["google"] = object()
+    speech_manager.tts_services["second"] = object()
+
+    resolved = speech_manager.resolve_tts_provider(None)
+
+    assert resolved == "google"
+
+
+def test_resolve_tts_provider_handles_no_services(speech_manager):
+    assert speech_manager.resolve_tts_provider("whatever") is None
+
+
 def test_get_stt_provider_names_returns_ordered_copy(speech_manager):
     speech_manager.stt_services["delta"] = object()
     speech_manager.stt_services["epsilon"] = object()


### PR DESCRIPTION
## Summary
- add a SpeechManager helper that resolves a preferred TTS provider and gracefully falls back to Eleven Labs or the first available provider
- update the Eleven Labs settings UI to rely on the helper before fetching voices or applying selections
- extend the unit tests to cover the new resolver fallbacks

## Testing
- pytest tests/test_speech_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68cf24e515f083228ef6edf9931e5802