### PR TITLE
Decouple persona manager message dispatching from GTK UI

### DIFF
--- a/ATLAS/persona_manager.py
+++ b/ATLAS/persona_manager.py
@@ -310,11 +310,20 @@ class PersonaManager:
         return {"success": True, "persona": persona}
 
     def show_message(self, role: str, message: str):
-        """Display a message using the chat component, if available."""
-        if hasattr(self.master, 'chat_component'):
-            self.master.chat_component.show_message(role, message)
-        else:
-            self.logger.warning("ChatComponent instance not found in master. Unable to display message.")
+        """Dispatch a persona-related message via the master callback when available."""
+        dispatcher = getattr(self.master, "message_dispatcher", None)
+
+        if not callable(dispatcher):
+            self.logger.warning(
+                "No message dispatcher registered on master. Unable to deliver persona message: %s",
+                message,
+            )
+            return
+
+        try:
+            dispatcher(role, message)
+        except Exception as exc:
+            self.logger.error("Message dispatcher failed: %s", exc, exc_info=True)
 
     def get_current_persona_prompt(self) -> str:
         """Returns the current persona's system prompt."""


### PR DESCRIPTION
## Summary
- add message dispatcher registration utilities to the ATLAS core and expose an aggregated callback for backend components
- route persona manager notifications through the registered dispatcher instead of touching GTK chat widgets directly
- register the persona management UI to present backend persona messages via a GTK dialog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf32e885348322bb8430eb30a9c282