### PR TITLE
Add provider change listener registry

### DIFF
--- a/GTKUI/Chat/chat_page.py
+++ b/GTKUI/Chat/chat_page.py
@@ -183,7 +183,9 @@ class ChatPage(Gtk.Window):
         self.update_status_bar()
 
         # Link provider changes to update the status bar.
-        self.ATLAS.notify_provider_changed = self.update_status_bar
+        self._provider_change_handler = self.update_status_bar
+        self.ATLAS.add_provider_change_listener(self._provider_change_handler)
+        self.connect("close-request", self._on_close_request)
 
         self.awaiting_response = False
         self._export_dialog = None
@@ -558,6 +560,12 @@ class ChatPage(Gtk.Window):
             dialog.destroy()
             if self._export_dialog is dialog:
                 self._export_dialog = None
+
+    def _on_close_request(self, *_args):
+        """Unregister provider change listeners before the window closes."""
+
+        self.ATLAS.remove_provider_change_listener(self._provider_change_handler)
+        return False
 
     def update_status_bar(self, provider=None, model=None):
         """

--- a/modules/Speech_Services/complete speech services
+++ b/modules/Speech_Services/complete speech services
@@ -1094,9 +1094,17 @@ class ChatPage(Gtk.Window):
         self.update_status_bar()
 
         # Link provider changes to update the status bar.
-        self.ATLAS.notify_provider_changed = self.update_status_bar
+        self._provider_change_handler = self.update_status_bar
+        self.ATLAS.add_provider_change_listener(self._provider_change_handler)
+        self.connect("close-request", self._on_close_request)
 
         self.present()
+
+    def _on_close_request(self, *_args):
+        """Unregister provider change listeners before the window closes."""
+
+        self.ATLAS.remove_provider_change_listener(self._provider_change_handler)
+        return False
 
     def update_persona_label(self):
         """
@@ -2214,9 +2222,17 @@ class ChatPage(Gtk.Window):
         self.update_status_bar()
 
         # Link provider changes to update the status bar.
-        self.ATLAS.notify_provider_changed = self.update_status_bar
+        self._provider_change_handler = self.update_status_bar
+        self.ATLAS.add_provider_change_listener(self._provider_change_handler)
+        self.connect("close-request", self._on_close_request)
 
         self.present()
+
+    def _on_close_request(self, *_args):
+        """Unregister provider change listeners before the window closes."""
+
+        self.ATLAS.remove_provider_change_listener(self._provider_change_handler)
+        return False
 
     def update_persona_label(self):
         """


### PR DESCRIPTION
## Summary
- add a provider change listener registry in the ATLAS core with add/remove helpers
- notify registered observers when providers change and update the GTK chat UI to use the helpers
- migrate other GTK speech UI windows to register/unregister provider change handlers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf499c2f0883229a1778f10edfcd34