### PR TITLE
Add SpeechManager default configuration helper

### DIFF
--- a/GTKUI/Settings/Speech/speech_settings.py
+++ b/GTKUI/Settings/Speech/speech_settings.py
@@ -372,25 +372,16 @@ class SpeechSettings(Gtk.Window):
     def save_general_tab(self):
         tts_enabled = self.general_tts_switch.get_active()
         stt_enabled = self.general_stt_switch.get_active()
-        current_tts_provider = self.ATLAS.speech_manager.get_default_tts_provider()
-        self.ATLAS.speech_manager.set_tts_status(tts_enabled, current_tts_provider)
         selected_tts_provider = self.default_tts_combo.get_active_text()
-        selected_stt_provider = self.default_stt_combo.get_active_text() if stt_enabled else None
+        selected_stt_provider = self.default_stt_combo.get_active_text()
 
-        self.ATLAS.speech_manager.set_default_speech_providers(
+        self.ATLAS.speech_manager.configure_defaults(
+            tts_enabled=tts_enabled,
             tts_provider=selected_tts_provider,
+            stt_enabled=stt_enabled,
             stt_provider=selected_stt_provider,
         )
 
-        if not stt_enabled:
-            self.ATLAS.speech_manager.disable_stt()
-            logger.info("General: STT disabled.")
-        else:
-            if selected_stt_provider:
-                logger.info(f"General: Default STT provider set to: {selected_stt_provider}")
-
-        if selected_tts_provider:
-            logger.info(f"General: Default TTS provider set to: {selected_tts_provider}")
         self.tab_dirty[0] = False
 
     # ----------------------- Eleven Labs TTS Tab -----------------------

--- a/modules/Speech_Services/speech_manager.py
+++ b/modules/Speech_Services/speech_manager.py
@@ -698,6 +698,30 @@ class SpeechManager:
         except ValueError:
             return None
 
+    def configure_defaults(
+        self,
+        *,
+        tts_enabled: bool,
+        tts_provider: Optional[str] = None,
+        stt_enabled: bool,
+        stt_provider: Optional[str] = None,
+    ) -> None:
+        """Configure global speech defaults and perform related cleanup."""
+
+        self.set_tts_status(bool(tts_enabled))
+
+        if tts_provider and tts_provider in self.tts_services:
+            self.set_tts_status(bool(tts_enabled), tts_provider)
+
+        effective_stt_provider = stt_provider if stt_enabled else None
+        self.set_default_speech_providers(
+            tts_provider=tts_provider,
+            stt_provider=effective_stt_provider,
+        )
+
+        if not stt_enabled:
+            self.disable_stt()
+
     def set_default_speech_providers(self, tts_provider: Optional[str] = None, stt_provider: Optional[str] = None):
         """Update the default TTS and/or STT providers in a single call."""
 


### PR DESCRIPTION
## Summary
- add a configure_defaults helper on SpeechManager to synchronize enable flags, providers, and cleanup
- replace the general speech settings save logic with a call to the new helper
- cover the helper with tests ensuring persistence and disable flows work as expected

## Testing
- pytest tests/test_speech_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d03176ced08322b633e92b6304ca00