### PR TITLE
Fix GTK MessageDialog initialization

### DIFF
--- a/GTKUI/Settings/Speech/speech_settings.py
+++ b/GTKUI/Settings/Speech/speech_settings.py
@@ -187,7 +187,7 @@ class SpeechSettings(Gtk.Window):
     def _show_message(self, title: str, message: str, message_type: Gtk.MessageType = Gtk.MessageType.INFO):
         dialog = Gtk.MessageDialog(
             transient_for=self,
-            flags=0,
+            modal=True,
             message_type=message_type,
             buttons=Gtk.ButtonsType.OK,
             text=title,
@@ -254,7 +254,7 @@ class SpeechSettings(Gtk.Window):
         if self.tab_dirty.get(old_index, False):
             dialog = Gtk.MessageDialog(
                 transient_for=self,
-                flags=0,
+                modal=True,
                 message_type=Gtk.MessageType.WARNING,
                 buttons=Gtk.ButtonsType.NONE,
                 text="You have unsaved changes in this tab."


### PR DESCRIPTION
## Summary
- update speech settings dialogs to construct Gtk.MessageDialog without the deprecated `flags` parameter
- ensure the dialogs remain modal under GTK 4 by explicitly requesting modal behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d034e459a883228f80894fc98e54da