### PR TITLE
Centralize persona prompt previews and helpers

### DIFF
--- a/GTKUI/Persona_manager/persona_management.py
+++ b/GTKUI/Persona_manager/persona_management.py
@@ -266,7 +266,7 @@ class PersonaManagement:
         main_vbox.append(stack)
 
         # General Tab (with scrollable box)
-        self.general_tab = GeneralTab(persona)
+        self.general_tab = GeneralTab(persona, self.ATLAS.persona_manager)
         general_box = self.general_tab.get_widget()
         scrolled_general_tab = Gtk.ScrolledWindow()
         scrolled_general_tab.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)


### PR DESCRIPTION
## Summary
- add PersonaManager helpers to derive canonical start/end prompt sections and a reusable default template
- ensure persona form saves regenerate the computed sections and expose a preview_prompt_sections utility
- update the GTK general tab to request previews from the manager and drop hard-coded templates, wiring refreshes for toggle changes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d03804e26883228339e0a340eff21c