### PR TITLE
Refactor persona mutations through manager APIs

### DIFF
--- a/GTKUI/Persona_manager/persona_management.py
+++ b/GTKUI/Persona_manager/persona_management.py
@@ -266,7 +266,7 @@ class PersonaManagement:
         main_vbox.append(stack)
 
         # General Tab (with scrollable box)
-        self.general_tab = GeneralTab(persona)
+        self.general_tab = GeneralTab(persona, self.ATLAS.persona_manager)
         general_box = self.general_tab.get_widget()
         scrolled_general_tab = Gtk.ScrolledWindow()
         scrolled_general_tab.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)


### PR DESCRIPTION
## Summary
- add explicit PersonaManager mutation helpers and route form updates through them
- teach the GTK general tab to toggle persona flags via the manager and sync its state from responses
- update GTK persona type tab switches to use the backend APIs and refresh UI bindings

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d038b321ac8322bc3baa1ce65c2327