### PR TITLE
Add ATLAS HuggingFace wrappers and UI integration

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -33,6 +33,14 @@ class ATLAS:
         self.message_dispatcher: Optional[Callable[[str, str], None]] = None
         self._default_status_tooltip = "Active LLM provider/model and TTS status"
 
+    def _require_provider_manager(self) -> ProviderManager:
+        """Return the initialized provider manager or raise an error if unavailable."""
+
+        if self.provider_manager is None:
+            raise RuntimeError("Provider manager is not initialized.")
+
+        return self.provider_manager
+
     async def initialize(self):
         """
         Asynchronously initialize the ATLAS instance.
@@ -108,6 +116,67 @@ class ATLAS:
         """Validate a HuggingFace API token via the provider manager."""
 
         return await self.provider_manager.test_huggingface_token(token)
+
+    def list_hf_models(self) -> Dict[str, Any]:
+        """List installed HuggingFace models via the provider manager."""
+
+        return self._require_provider_manager().list_hf_models()
+
+    async def load_hf_model(self, model_name: str, force_download: bool = False) -> Dict[str, Any]:
+        """Load a HuggingFace model using the provider manager helper."""
+
+        return await self._require_provider_manager().load_hf_model(
+            model_name, force_download=force_download
+        )
+
+    async def unload_hf_model(self) -> Dict[str, Any]:
+        """Unload the active HuggingFace model via the provider manager."""
+
+        return await self._require_provider_manager().unload_hf_model()
+
+    async def remove_hf_model(self, model_name: str) -> Dict[str, Any]:
+        """Remove a cached HuggingFace model through the provider manager."""
+
+        return await self._require_provider_manager().remove_hf_model(model_name)
+
+    async def download_hf_model(self, model_id: str, force: bool = False) -> Dict[str, Any]:
+        """Download a HuggingFace model through the provider manager."""
+
+        return await self._require_provider_manager().download_huggingface_model(model_id, force=force)
+
+    async def search_hf_models(
+        self,
+        search_query: str,
+        filters: Optional[Dict[str, Any]] = None,
+        limit: int = 10,
+    ) -> Dict[str, Any]:
+        """Search HuggingFace models using the provider manager helper."""
+
+        return await self._require_provider_manager().search_huggingface_models(
+            search_query,
+            filters,
+            limit=limit,
+        )
+
+    def update_hf_settings(self, settings: Dict[str, Any]) -> Dict[str, Any]:
+        """Persist HuggingFace settings via the provider manager."""
+
+        return self._require_provider_manager().update_huggingface_settings(settings)
+
+    def clear_hf_cache(self) -> Dict[str, Any]:
+        """Clear cached HuggingFace artefacts through the provider manager."""
+
+        return self._require_provider_manager().clear_huggingface_cache()
+
+    def save_hf_token(self, token: Optional[str]) -> Dict[str, Any]:
+        """Save a Hugging Face token via the provider manager."""
+
+        return self._require_provider_manager().save_huggingface_token(token)
+
+    def get_provider_api_key_status(self, provider_name: str) -> Dict[str, Any]:
+        """Fetch credential metadata for a provider using the provider manager."""
+
+        return self._require_provider_manager().get_provider_api_key_status(provider_name)
 
     async def set_current_provider(self, provider: str):
         """

--- a/GTKUI/Provider_manager/Settings/HF_settings.py
+++ b/GTKUI/Provider_manager/Settings/HF_settings.py
@@ -197,8 +197,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
     def _get_provider_key_status(self, provider_name: str) -> Dict[str, Any]:
         """Fetch sanitized provider credential metadata from the backend manager."""
 
-        manager = getattr(self.ATLAS, "provider_manager", None)
-        getter = getattr(manager, "get_provider_api_key_status", None)
+        getter = getattr(self.ATLAS, "get_provider_api_key_status", None)
         if not callable(getter):
             logger.debug("Provider manager helper for credential status is unavailable.")
             return {"has_key": False, "metadata": {}}
@@ -995,7 +994,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
         Populates the model, remove model, and update model combo boxes with
         the installed models obtained via the HuggingFace generator.
         """
-        result = self.ATLAS.provider_manager.list_hf_models()
+        result = self.ATLAS.list_hf_models()
         self.model_combo.remove_all()
         self.remove_model_combo.remove_all()
         self.update_model_combo.remove_all()
@@ -1024,7 +1023,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
         selected_model = self.model_combo.get_active_text()
         if selected_model:
             self._run_async(
-                self.ATLAS.provider_manager.load_hf_model(selected_model),
+                self.ATLAS.load_hf_model(selected_model),
                 success_callback=lambda res, model=selected_model: self._dispatch_provider_result(
                     res,
                     success_message=f"Model '{model}' loaded successfully.",
@@ -1044,7 +1043,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
         Callback for unloading the current model.
         """
         self._run_async(
-            self.ATLAS.provider_manager.unload_hf_model(),
+            self.ATLAS.unload_hf_model(),
             success_callback=lambda res: self._dispatch_provider_result(
                 res,
                 success_message="Model unloaded successfully.",
@@ -1109,7 +1108,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
                 "logging_level": self.log_level_combo.get_active_text(),
                 "current_model": self.model_combo.get_active_text(),
             }
-            result = self.ATLAS.provider_manager.update_huggingface_settings(settings)
+            result = self.ATLAS.update_hf_settings(settings)
             self._dispatch_provider_result(
                 result,
                 success_message="Your settings have been saved successfully.",
@@ -1135,7 +1134,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
         confirmation = self.confirm_dialog("Are you sure you want to clear the Hugging Face cache?")
         if confirmation:
             try:
-                result = self.ATLAS.provider_manager.clear_huggingface_cache()
+                result = self.ATLAS.clear_hf_cache()
                 self._dispatch_provider_result(
                     result,
                     success_message="Cache cleared successfully.",
@@ -1153,7 +1152,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
             confirmation = self.confirm_dialog(f"Are you sure you want to remove the model '{selected_model}'?")
             if confirmation:
                 self._run_async(
-                    self.ATLAS.provider_manager.remove_hf_model(selected_model),
+                    self.ATLAS.remove_hf_model(selected_model),
                     success_callback=lambda res, model=selected_model: self._dispatch_provider_result(
                         res,
                         success_message=f"Model '{model}' removed successfully.",
@@ -1179,7 +1178,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
             confirmation = self.confirm_dialog(f"Do you want to update the model '{selected_model}'?")
             if confirmation:
                 self._run_async(
-                    self.ATLAS.provider_manager.download_huggingface_model(selected_model, force=True),
+                    self.ATLAS.download_hf_model(selected_model, force=True),
                     success_callback=lambda res, model=selected_model: self._dispatch_provider_result(
                         res,
                         success_message=f"Model '{model}' updated successfully.",
@@ -1220,7 +1219,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
             filter_args["library_name"] = library
 
         self._run_async(
-            self.ATLAS.provider_manager.search_huggingface_models(search_query, filter_args, limit=10),
+            self.ATLAS.search_hf_models(search_query, filter_args, limit=10),
             success_callback=self._handle_search_results,
             error_callback=lambda e: self.show_message(
                 "Error",
@@ -1293,7 +1292,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
         confirmation = self.confirm_dialog(f"Do you want to download and install the model '{model_name}'?")
         if confirmation:
             self._run_async(
-                self.ATLAS.provider_manager.download_huggingface_model(model_name, force=True),
+                self.ATLAS.download_hf_model(model_name, force=True),
                 success_callback=lambda res, model=model_name: self._dispatch_provider_result(
                     res,
                     success_message=f"Model '{model}' downloaded and installed successfully.",
@@ -1316,7 +1315,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
         Persist the Hugging Face token using the provider manager helper.
         """
 
-        backend = getattr(getattr(self.ATLAS, "provider_manager", None), "save_huggingface_token", None)
+        backend = getattr(self.ATLAS, "save_hf_token", None)
         if not callable(backend):
             self.show_message(
                 "Error",
@@ -1360,7 +1359,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
             return
 
         self._run_async(
-            self.ATLAS.provider_manager.test_huggingface_token(token_input or None),
+            self.ATLAS.test_huggingface_token(token_input or None),
             success_callback=self._handle_token_test_result,
             error_callback=lambda exc: self.show_message(
                 "Error",

--- a/tests/test_atlas_provider_wrappers.py
+++ b/tests/test_atlas_provider_wrappers.py
@@ -1,0 +1,308 @@
+import asyncio
+import importlib
+import importlib
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+@pytest.fixture
+def atlas_class(monkeypatch):
+    """Provide the ATLAS class with provider manager dependencies stubbed."""
+
+    def ensure_module(name: str, module: types.ModuleType) -> None:
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1]))
+
+    # Reuse existing test stubs for extensive dependency mocking.
+    import tests.test_atlas_status  # noqa: F401
+    import tests.test_speech_manager  # noqa: F401
+
+    yaml_stub = types.ModuleType("yaml")
+    yaml_stub.safe_load = lambda *_args, **_kwargs: {}
+    yaml_stub.dump = lambda *_args, **_kwargs: ""
+    ensure_module("yaml", yaml_stub)
+
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *_args, **_kwargs: None
+    dotenv_stub.set_key = lambda *_args, **_kwargs: None
+    dotenv_stub.find_dotenv = lambda *_args, **_kwargs: ""
+    ensure_module("dotenv", dotenv_stub)
+
+    hf_api_module = types.ModuleType("huggingface_hub")
+
+    class _StubHfApi:
+        def whoami(self, *_args, **_kwargs):
+            return {}
+
+    hf_api_module.HfApi = _StubHfApi
+    ensure_module("huggingface_hub", hf_api_module)
+
+    hf_module = types.ModuleType("modules.Providers.HuggingFace.HF_gen_response")
+
+    class _FakeModelManager:
+        def __init__(self):
+            self.installed = []
+
+        def remove_installed_model(self, model_name):
+            self.installed = [m for m in self.installed if m != model_name]
+
+    class _HuggingFaceGenerator:
+        def __init__(self, *_args, **_kwargs):
+            self.model_manager = _FakeModelManager()
+
+        async def load_model(self, model_name, *_args, **_kwargs):
+            self.model_manager.installed.append(model_name)
+
+        def unload_model(self):
+            return None
+
+        def get_installed_models(self):
+            return list(self.model_manager.installed)
+
+    async def _hf_search(generator, *_args, **_kwargs):  # pragma: no cover - stub helper
+        return []
+
+    async def _hf_download(generator, model_id, force=False):  # pragma: no cover - stub helper
+        generator.model_manager.installed.append(model_id)
+
+    def _hf_update(generator, settings):  # pragma: no cover - stub helper
+        return settings
+
+    hf_module.HuggingFaceGenerator = _HuggingFaceGenerator
+    hf_module.search_models = _hf_search
+    hf_module.download_model = _hf_download
+    hf_module.update_model_settings = _hf_update
+    hf_module.clear_cache = lambda *_args, **_kwargs: None
+    ensure_module("modules.Providers.HuggingFace.HF_gen_response", hf_module)
+
+    grok_module = types.ModuleType("modules.Providers.Grok.grok_generate_response")
+
+    class _GrokGenerator:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def generate_response(self, *_args, **_kwargs):  # pragma: no cover - stub helper
+            return ""
+
+        async def process_streaming_response(self, response):  # pragma: no cover - stub helper
+            collected = []
+            async for chunk in response:
+                collected.append(chunk)
+            return "".join(collected)
+
+        async def unload_model(self):  # pragma: no cover - stub helper
+            return None
+
+    grok_module.GrokGenerator = _GrokGenerator
+    ensure_module("modules.Providers.Grok.grok_generate_response", grok_module)
+
+    def _make_async_provider_module(name: str) -> types.ModuleType:
+        module = types.ModuleType(name)
+
+        async def _generate_response(*_args, **_kwargs):  # pragma: no cover - stub helper
+            return ""
+
+        module.generate_response = _generate_response
+        return module
+
+    for provider_module in [
+        "modules.Providers.OpenAI.OA_gen_response",
+        "modules.Providers.Mistral.Mistral_gen_response",
+        "modules.Providers.Google.GG_gen_response",
+        "modules.Providers.Anthropic.Anthropic_gen_response",
+    ]:
+        ensure_module(provider_module, _make_async_provider_module(provider_module))
+
+    google_module = types.ModuleType("google")
+    google_module.__path__ = []
+    cloud_module = types.ModuleType("google.cloud")
+    cloud_module.__path__ = []
+    speech_module = types.ModuleType("google.cloud.speech_v1p1beta1")
+
+    class _DummySpeechClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def synthesize_speech(self, *_args, **_kwargs):
+            return types.SimpleNamespace(audio_content=b"")
+
+        def list_voices(self, *_args, **_kwargs):
+            return types.SimpleNamespace(voices=[])
+
+    class _DummySsmlVoiceGender:
+        NEUTRAL = 0
+
+        def __call__(self, *_args, **_kwargs):
+            return types.SimpleNamespace(name="NEUTRAL")
+
+    speech_module.SpeechClient = _DummySpeechClient
+    speech_module.SynthesisInput = lambda *_args, **_kwargs: None
+    speech_module.AudioConfig = lambda *_args, **_kwargs: None
+    speech_module.AudioEncoding = types.SimpleNamespace(MP3="MP3")
+    speech_module.SsmlVoiceGender = _DummySsmlVoiceGender()
+    speech_module.VoiceSelectionParams = lambda *_args, **_kwargs: None
+
+    cloud_module.speech_v1p1beta1 = speech_module
+    google_module.cloud = cloud_module
+    ensure_module("google", google_module)
+    ensure_module("google.cloud", cloud_module)
+    ensure_module("google.cloud.speech_v1p1beta1", speech_module)
+
+    if "pygame" not in sys.modules:
+        music = types.SimpleNamespace(
+            load=lambda *_args, **_kwargs: None,
+            play=lambda *_args, **_kwargs: None,
+            get_busy=lambda: False,
+        )
+        mixer = types.SimpleNamespace(init=lambda *_args, **_kwargs: None, music=music)
+
+        class _DummyClock:
+            def tick(self, *_args, **_kwargs):
+                return None
+
+        pygame_stub = types.ModuleType("pygame")
+        pygame_stub.mixer = mixer
+        pygame_stub.time = types.SimpleNamespace(Clock=lambda: _DummyClock())
+        ensure_module("pygame", pygame_stub)
+
+    if "requests" not in sys.modules:
+        class _DummyResponse:
+            ok = True
+            text = ""
+
+            def json(self):
+                return {}
+
+            def iter_content(self, chunk_size=1024):  # pragma: no cover - stub helper
+                return iter(())
+
+        def _dummy_request(*_args, **_kwargs):  # pragma: no cover - stub helper
+            return _DummyResponse()
+
+        requests_stub = types.ModuleType("requests")
+        requests_stub.get = _dummy_request
+        requests_stub.post = _dummy_request
+        ensure_module("requests", requests_stub)
+
+    if "numpy" not in sys.modules:
+        numpy_stub = types.ModuleType("numpy")
+        numpy_stub.array = lambda *_args, **_kwargs: []
+        numpy_stub.zeros = lambda *_args, **_kwargs: []
+        ensure_module("numpy", numpy_stub)
+
+    if "soundfile" not in sys.modules:
+        soundfile_stub = types.ModuleType("soundfile")
+        soundfile_stub.read = lambda *_args, **_kwargs: ([], 0)
+        soundfile_stub.write = lambda *_args, **_kwargs: None
+        ensure_module("soundfile", soundfile_stub)
+
+    if "sounddevice" not in sys.modules:
+        class _DummyInputStream:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def start(self):
+                return None
+
+            def stop(self):
+                return None
+
+        sounddevice_stub = types.ModuleType("sounddevice")
+        sounddevice_stub.InputStream = _DummyInputStream
+        ensure_module("sounddevice", sounddevice_stub)
+
+    for module_name in ["ATLAS.ATLAS", "ATLAS.provider_manager"]:
+        sys.modules.pop(module_name, None)
+
+    importlib.import_module("ATLAS")
+    atlas_module = importlib.import_module("ATLAS.ATLAS")
+    return atlas_module.ATLAS
+
+
+def _build_atlas(atlas_class):
+    atlas = atlas_class.__new__(atlas_class)
+    atlas.provider_manager = None
+    return atlas
+
+
+def test_hf_wrappers_require_provider_manager(atlas_class):
+    atlas = _build_atlas(atlas_class)
+    with pytest.raises(RuntimeError):
+        atlas.list_hf_models()
+
+
+@pytest.mark.parametrize(
+    "wrapper_name, provider_attr, args, kwargs",
+    [
+        ("load_hf_model", "load_hf_model", ("alpha",), {"force_download": True}),
+        ("unload_hf_model", "unload_hf_model", tuple(), {}),
+        ("remove_hf_model", "remove_hf_model", ("beta",), {}),
+        ("download_hf_model", "download_huggingface_model", ("gamma",), {"force": True}),
+        (
+            "search_hf_models",
+            "search_huggingface_models",
+            ("llama", {"pipeline_tag": "text-generation"}),
+            {"limit": 5},
+        ),
+    ],
+)
+def test_async_hf_wrappers_delegate(atlas_class, wrapper_name, provider_attr, args, kwargs):
+    atlas = _build_atlas(atlas_class)
+    expected = {"success": True, "message": "ok"}
+    async_mock = AsyncMock(return_value=expected)
+    atlas.provider_manager = SimpleNamespace(**{provider_attr: async_mock})
+
+    result = asyncio.run(getattr(atlas, wrapper_name)(*args, **kwargs))
+
+    assert result is expected
+    async_mock.assert_awaited_once_with(*args, **kwargs)
+
+
+def test_async_hf_wrappers_propagate_exceptions(atlas_class):
+    atlas = _build_atlas(atlas_class)
+    failure = RuntimeError("boom")
+    atlas.provider_manager = SimpleNamespace(load_hf_model=AsyncMock(side_effect=failure))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(atlas.load_hf_model("alpha"))
+
+    assert excinfo.value is failure
+
+
+@pytest.mark.parametrize(
+    "wrapper_name, provider_attr, args, kwargs",
+    [
+        ("list_hf_models", "list_hf_models", tuple(), {}),
+        ("update_hf_settings", "update_huggingface_settings", ({"temperature": 0.5},), {}),
+        ("clear_hf_cache", "clear_huggingface_cache", tuple(), {}),
+        ("save_hf_token", "save_huggingface_token", ("token",), {}),
+        ("get_provider_api_key_status", "get_provider_api_key_status", ("HuggingFace",), {}),
+    ],
+)
+def test_sync_hf_wrappers_delegate(atlas_class, wrapper_name, provider_attr, args, kwargs):
+    atlas = _build_atlas(atlas_class)
+    expected = {"success": True, "message": "ok"}
+    mock_method = Mock(return_value=expected)
+    atlas.provider_manager = SimpleNamespace(**{provider_attr: mock_method})
+
+    result = getattr(atlas, wrapper_name)(*args, **kwargs)
+
+    assert result is expected
+    mock_method.assert_called_once_with(*args, **kwargs)
+
+
+def test_sync_hf_wrappers_propagate_exceptions(atlas_class):
+    atlas = _build_atlas(atlas_class)
+    failure = ValueError("bad cache")
+    atlas.provider_manager = SimpleNamespace(clear_huggingface_cache=Mock(side_effect=failure))
+
+    with pytest.raises(ValueError) as excinfo:
+        atlas.clear_hf_cache()
+
+    assert excinfo.value is failure


### PR DESCRIPTION
## Summary
- add provider manager wrapper helpers to `ATLAS/ATLAS.py`
- update the GTK Hugging Face settings panel to use the new ATLAS surface
- cover the new wrapper methods with focused tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d09a1cf6b08322aaf7935a6e1c4485