### PR TITLE
Add OpenAI provider settings UI and persistence

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -433,6 +433,43 @@ class ATLAS:
         """
         return self.provider_manager.get_current_model()
 
+    def get_openai_llm_settings(self) -> Dict[str, Any]:
+        """Expose the persisted OpenAI LLM defaults."""
+
+        provider_manager = getattr(self, "provider_manager", None)
+        if provider_manager is not None:
+            getter = getattr(provider_manager, "get_openai_llm_settings", None)
+            if callable(getter):
+                return getter()
+
+        return self.config_manager.get_openai_llm_settings()
+
+    def set_openai_llm_settings(
+        self,
+        *,
+        model: str,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stream: Optional[bool] = None,
+        base_url: Optional[str] = None,
+        organization: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Persist OpenAI defaults through the provider manager facade."""
+
+        manager = self._require_provider_manager()
+        setter = getattr(manager, "set_openai_llm_settings", None)
+        if not callable(setter):
+            raise AttributeError("Provider manager does not support OpenAI settings updates.")
+
+        return setter(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=stream,
+            base_url=base_url,
+            organization=organization,
+        )
+
     def get_chat_status_summary(self) -> Dict[str, str]:
         """Return a consolidated snapshot of chat-related status information."""
 

--- a/ATLAS/config.py
+++ b/ATLAS/config.py
@@ -27,6 +27,7 @@ class ConfigManager:
         
         # Load configurations from .env and config.yaml
         self.env_config = self._load_env_config()
+        self._yaml_path = self._compute_yaml_path()
         self.yaml_config = self._load_yaml_config()
         
         # Merge configurations, with YAML config overriding env config if there's overlap
@@ -61,6 +62,16 @@ class ConfigManager:
             "ElevenLabs": "XI_API_KEY",
         }
 
+    def _compute_yaml_path(self) -> str:
+        """Return the absolute path to the persistent YAML configuration file."""
+
+        return os.path.join(
+            self.env_config.get('APP_ROOT', '.'),
+            'ATLAS',
+            'config',
+            'atlas_config.yaml',
+        )
+
     def _load_env_config(self) -> Dict[str, Any]:
         """
         Loads environment variables into the configuration dictionary.
@@ -78,6 +89,8 @@ class ConfigManager:
             'ANTHROPIC_API_KEY': os.getenv('ANTHROPIC_API_KEY'),
             'GROK_API_KEY': os.getenv('GROK_API_KEY'),
             'XI_API_KEY': os.getenv('XI_API_KEY'),
+            'OPENAI_BASE_URL': os.getenv('OPENAI_BASE_URL'),
+            'OPENAI_ORGANIZATION': os.getenv('OPENAI_ORGANIZATION'),
             'APP_ROOT': os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         }
         self.logger.info(f"APP_ROOT is set to: {config['APP_ROOT']}")
@@ -90,9 +103,8 @@ class ConfigManager:
         Returns:
             Dict[str, Any]: A dictionary containing all loaded YAML configuration settings.
         """
-        # Construct the path to config.yaml based on APP_ROOT
-        yaml_path = os.path.join(self.env_config.get('APP_ROOT', '.'), 'ATLAS', 'config', 'atlas_config.yaml')
-        
+        yaml_path = getattr(self, '_yaml_path', None) or self._compute_yaml_path()
+
         if not os.path.exists(yaml_path):
             self.logger.error(f"Configuration file not found: {yaml_path}")
             return {}
@@ -188,6 +200,69 @@ class ConfigManager:
             elif key in self.config:
                 self.config[key] = None
 
+    def set_openai_llm_settings(
+        self,
+        *,
+        model: Optional[str],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stream: Optional[bool] = None,
+        base_url: Optional[str] = None,
+        organization: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Persist OpenAI chat-completion defaults and related metadata."""
+
+        if not model:
+            raise ValueError("A default OpenAI model must be provided.")
+
+        normalized_temperature = 0.0 if temperature is None else float(temperature)
+        if not 0.0 <= normalized_temperature <= 2.0:
+            raise ValueError("Temperature must be between 0.0 and 2.0.")
+
+        normalized_max_tokens = 4000 if max_tokens is None else int(max_tokens)
+        if normalized_max_tokens <= 0:
+            raise ValueError("Max tokens must be a positive integer.")
+
+        normalized_stream = True if stream is None else bool(stream)
+
+        sanitized_base_url = (base_url or "").strip() or None
+        sanitized_org = (organization or "").strip() or None
+
+        settings_block = {}
+        existing = self.yaml_config.get('OPENAI_LLM')
+        if isinstance(existing, dict):
+            settings_block.update(existing)
+
+        settings_block.update(
+            {
+                'model': model,
+                'temperature': normalized_temperature,
+                'max_tokens': normalized_max_tokens,
+                'stream': normalized_stream,
+                'base_url': sanitized_base_url,
+                'organization': sanitized_org,
+            }
+        )
+
+        self.yaml_config['OPENAI_LLM'] = settings_block
+        self.config['OPENAI_LLM'] = dict(settings_block)
+
+        # Persist environment-backed values.
+        self._persist_env_value('DEFAULT_MODEL', model)
+        self.config['DEFAULT_MODEL'] = model
+
+        self._persist_env_value('OPENAI_BASE_URL', sanitized_base_url)
+        self._persist_env_value('OPENAI_ORGANIZATION', sanitized_org)
+
+        # Synchronize cached environment map for convenience.
+        self.env_config['DEFAULT_MODEL'] = model
+        self.env_config['OPENAI_BASE_URL'] = sanitized_base_url
+        self.env_config['OPENAI_ORGANIZATION'] = sanitized_org
+
+        self._write_yaml_config()
+
+        return dict(settings_block)
+
 
     def get_config(self, key: str, default: Any = None) -> Any:
         """
@@ -228,6 +303,24 @@ class ConfigManager:
             str: The name of the default model.
         """
         return self.get_config('DEFAULT_MODEL')
+
+    def get_openai_llm_settings(self) -> Dict[str, Any]:
+        """Return persisted OpenAI LLM defaults merged with environment values."""
+
+        defaults = {
+            'model': self.get_config('DEFAULT_MODEL', 'gpt-4o'),
+            'temperature': 0.0,
+            'max_tokens': 4000,
+            'stream': True,
+            'base_url': self.get_config('OPENAI_BASE_URL'),
+            'organization': self.get_config('OPENAI_ORGANIZATION'),
+        }
+
+        stored = self.get_config('OPENAI_LLM')
+        if isinstance(stored, dict):
+            defaults.update({k: stored.get(k, defaults.get(k)) for k in defaults.keys()})
+
+        return defaults
 
 
     def get_openai_api_key(self) -> str:
@@ -382,8 +475,9 @@ class ConfigManager:
         """
         Writes the current YAML configuration back to the config.yaml file.
         """
-        yaml_path = os.path.join(self.get_app_root(), 'config.yaml')
+        yaml_path = getattr(self, '_yaml_path', None) or self._compute_yaml_path()
         try:
+            os.makedirs(os.path.dirname(yaml_path), exist_ok=True)
             with open(yaml_path, 'w') as file:
                 yaml.dump(self.yaml_config, file)
             self.logger.info(f"Configuration written to {yaml_path}")

--- a/GTKUI/Provider_manager/Settings/OA_settings.py
+++ b/GTKUI/Provider_manager/Settings/OA_settings.py
@@ -1,0 +1,209 @@
+"""Dedicated GTK window for configuring OpenAI provider defaults."""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk, GLib
+
+from GTKUI.Utils.utils import create_box
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAISettingsWindow(Gtk.Window):
+    """Collect OpenAI-specific preferences such as default model and streaming mode."""
+
+    def __init__(self, ATLAS, config_manager, parent_window):
+        super().__init__(title="OpenAI Settings")
+        self.ATLAS = ATLAS
+        self.config_manager = config_manager
+        self.parent_window = parent_window
+        if parent_window is not None:
+            self.set_transient_for(parent_window)
+        self.set_modal(True)
+        self.set_default_size(420, 320)
+
+        self._last_message: Optional[Tuple[str, str, Gtk.MessageType]] = None
+
+        main_box = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=12, margin=12)
+        self.set_child(main_box)
+
+        grid = Gtk.Grid(column_spacing=12, row_spacing=8)
+        main_box.append(grid)
+
+        row = 0
+        model_label = Gtk.Label(label="Default Model:")
+        model_label.set_xalign(0.0)
+        grid.attach(model_label, 0, row, 1, 1)
+        self.model_combo = Gtk.ComboBoxText()
+        self.model_combo.set_hexpand(True)
+        grid.attach(self.model_combo, 1, row, 1, 1)
+
+        row += 1
+        temp_label = Gtk.Label(label="Temperature:")
+        temp_label.set_xalign(0.0)
+        grid.attach(temp_label, 0, row, 1, 1)
+        self.temperature_adjustment = Gtk.Adjustment(lower=0.0, upper=2.0, step_increment=0.05, page_increment=0.1, value=0.0)
+        self.temperature_spin = Gtk.SpinButton(adjustment=self.temperature_adjustment, digits=2)
+        self.temperature_spin.set_increments(0.05, 0.1)
+        self.temperature_spin.set_hexpand(True)
+        grid.attach(self.temperature_spin, 1, row, 1, 1)
+
+        row += 1
+        tokens_label = Gtk.Label(label="Max Tokens:")
+        tokens_label.set_xalign(0.0)
+        grid.attach(tokens_label, 0, row, 1, 1)
+        self.max_tokens_adjustment = Gtk.Adjustment(lower=1, upper=128000, step_increment=128, page_increment=512, value=4000)
+        self.max_tokens_spin = Gtk.SpinButton(adjustment=self.max_tokens_adjustment, digits=0)
+        self.max_tokens_spin.set_increments(128, 512)
+        self.max_tokens_spin.set_hexpand(True)
+        grid.attach(self.max_tokens_spin, 1, row, 1, 1)
+
+        row += 1
+        self.stream_toggle = Gtk.CheckButton(label="Enable streaming responses")
+        self.stream_toggle.set_halign(Gtk.Align.START)
+        grid.attach(self.stream_toggle, 0, row, 2, 1)
+
+        row += 1
+        base_url_label = Gtk.Label(label="Base URL (optional):")
+        base_url_label.set_xalign(0.0)
+        grid.attach(base_url_label, 0, row, 1, 1)
+        self.base_url_entry = Gtk.Entry()
+        self.base_url_entry.set_hexpand(True)
+        self.base_url_entry.set_placeholder_text("https://api.openai.com/v1")
+        grid.attach(self.base_url_entry, 1, row, 1, 1)
+
+        row += 1
+        org_label = Gtk.Label(label="Organization (optional):")
+        org_label.set_xalign(0.0)
+        grid.attach(org_label, 0, row, 1, 1)
+        self.organization_entry = Gtk.Entry()
+        self.organization_entry.set_hexpand(True)
+        self.organization_entry.set_placeholder_text("org-1234")
+        grid.attach(self.organization_entry, 1, row, 1, 1)
+
+        button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        button_box.set_halign(Gtk.Align.END)
+        main_box.append(button_box)
+
+        cancel_button = Gtk.Button(label="Cancel")
+        cancel_button.connect("clicked", lambda *_: self.close())
+        button_box.append(cancel_button)
+
+        save_button = Gtk.Button(label="Save Settings")
+        save_button.connect("clicked", self.on_save_clicked)
+        button_box.append(save_button)
+
+        self._populate_defaults()
+
+    def _populate_defaults(self) -> None:
+        settings = self._get_settings_snapshot()
+        models = self._load_available_models()
+
+        self.model_combo.remove_all()
+        if settings.get("model") and settings["model"] not in models:
+            models = [settings["model"]] + [name for name in models if name != settings["model"]]
+
+        if not models:
+            models = [settings.get("model") or "gpt-4o"]
+
+        active_index = 0
+        for idx, name in enumerate(models):
+            self.model_combo.append_text(name)
+            if name == settings.get("model"):
+                active_index = idx
+        self.model_combo.set_active(active_index)
+
+        self.temperature_spin.set_value(float(settings.get("temperature", 0.0)))
+        self.max_tokens_spin.set_value(float(settings.get("max_tokens", 4000)))
+        self.stream_toggle.set_active(bool(settings.get("stream", True)))
+        self.base_url_entry.set_text(settings.get("base_url") or "")
+        self.organization_entry.set_text(settings.get("organization") or "")
+
+    def _get_settings_snapshot(self) -> Dict[str, Any]:
+        try:
+            if hasattr(self.ATLAS, "get_openai_llm_settings"):
+                return dict(self.ATLAS.get_openai_llm_settings() or {})
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to read OpenAI settings from ATLAS: %s", exc, exc_info=True)
+
+        try:
+            return dict(self.config_manager.get_openai_llm_settings() or {})
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to read OpenAI settings from config manager: %s", exc, exc_info=True)
+            return {}
+
+    def _load_available_models(self) -> List[str]:
+        provider_manager = getattr(self.ATLAS, "provider_manager", None)
+        if provider_manager and getattr(provider_manager, "model_manager", None):
+            try:
+                payload = provider_manager.model_manager.get_available_models("OpenAI")
+                models = payload.get("OpenAI", [])
+                if isinstance(models, list):
+                    return list(models)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error("Failed to load OpenAI model list: %s", exc, exc_info=True)
+        return []
+
+    def on_save_clicked(self, _button: Gtk.Button):
+        model = self.model_combo.get_active_text()
+        if not model:
+            self._show_message("Error", "Please choose a default model before saving.", Gtk.MessageType.ERROR)
+            return
+
+        payload = {
+            "model": model,
+            "temperature": self.temperature_spin.get_value(),
+            "max_tokens": self.max_tokens_spin.get_value_as_int(),
+            "stream": self.stream_toggle.get_active(),
+            "base_url": self.base_url_entry.get_text().strip() or None,
+            "organization": self.organization_entry.get_text().strip() or None,
+        }
+
+        try:
+            result = self.ATLAS.set_openai_llm_settings(**payload)
+        except Exception as exc:
+            logger.error("Error saving OpenAI settings: %s", exc, exc_info=True)
+            self._show_message("Error", str(exc), Gtk.MessageType.ERROR)
+            return
+
+        if isinstance(result, dict) and result.get("success"):
+            message = result.get("message", "OpenAI settings saved.")
+            self._show_message("Success", message, Gtk.MessageType.INFO)
+            self.close()
+            return
+
+        if isinstance(result, dict):
+            detail = result.get("error") or result.get("message") or "Unable to save OpenAI settings."
+        elif result is None:
+            detail = "Unable to save OpenAI settings."
+        else:
+            detail = str(result)
+
+        self._show_message("Error", detail, Gtk.MessageType.ERROR)
+
+    def _show_message(self, title: str, message: str, message_type: Gtk.MessageType):
+        self._last_message = (title, message, message_type)
+
+        try:
+            dialog = Gtk.MessageDialog(
+                transient_for=self,
+                modal=True,
+                message_type=message_type,
+                buttons=Gtk.ButtonsType.OK,
+                text=title,
+            )
+        except Exception:  # pragma: no cover - fallback when running in stubbed environments
+            logger.debug("GTK message dialog unavailable; skipping display for '%s'.", title)
+            return
+
+        if hasattr(dialog, "set_secondary_text"):
+            dialog.set_secondary_text(message)
+        else:
+            dialog.props.secondary_text = message
+
+        dialog.connect("response", lambda dlg, *_: dlg.destroy())
+        GLib.idle_add(dialog.present)

--- a/GTKUI/Provider_manager/provider_management.py
+++ b/GTKUI/Provider_manager/provider_management.py
@@ -12,6 +12,7 @@ import logging
 
 from GTKUI.Utils.utils import create_box
 from .Settings.HF_settings import HuggingFaceSettingsWindow
+from .Settings.OA_settings import OpenAISettingsWindow
 
 class ProviderManagement:
     """
@@ -168,7 +169,9 @@ class ProviderManagement:
         if self.provider_window:
             GLib.idle_add(self.provider_window.close)
 
-        if provider_name == "HuggingFace":
+        if provider_name == "OpenAI":
+            self.show_openai_settings()
+        elif provider_name == "HuggingFace":
             try:
                 result = self.ATLAS.ensure_huggingface_ready()
             except AttributeError:
@@ -197,6 +200,13 @@ class ProviderManagement:
             self.show_huggingface_settings()
         else:
             self.show_provider_settings(provider_name)
+
+    def show_openai_settings(self):
+        """Display the OpenAI provider configuration dialog."""
+
+        settings_window = OpenAISettingsWindow(self.ATLAS, self.config_manager, self.parent_window)
+        settings_window.set_tooltip_text("Configure OpenAI default parameters and endpoints.")
+        settings_window.present()
 
     def show_huggingface_settings(self):
         """

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -51,6 +51,8 @@ def config_manager(tmp_path, monkeypatch):
             "ANTHROPIC_API_KEY": None,
             "GROK_API_KEY": None,
             "APP_ROOT": tmp_path.as_posix(),
+            "OPENAI_BASE_URL": os.getenv("OPENAI_BASE_URL"),
+            "OPENAI_ORGANIZATION": os.getenv("OPENAI_ORGANIZATION"),
         },
     )
     monkeypatch.setattr(ConfigManager, "_load_yaml_config", lambda self: {})
@@ -123,3 +125,45 @@ def test_set_hf_token_updates_state(config_manager):
         config_manager._recorded_set_key[(config_manager._env_path, "HUGGINGFACE_API_KEY")]
         == "hf-token"
     )
+
+
+def test_set_openai_llm_settings_updates_state(config_manager):
+    result = config_manager.set_openai_llm_settings(
+        model="gpt-4o-mini",
+        temperature=0.75,
+        max_tokens=2048,
+        stream=False,
+        base_url="https://example/v1",
+        organization="org-42",
+    )
+
+    assert result["model"] == "gpt-4o-mini"
+    stored = config_manager.config["OPENAI_LLM"]
+    assert stored["temperature"] == 0.75
+    assert stored["max_tokens"] == 2048
+    assert stored["stream"] is False
+    assert stored["base_url"] == "https://example/v1"
+    assert stored["organization"] == "org-42"
+
+    assert config_manager.config["DEFAULT_MODEL"] == "gpt-4o-mini"
+    assert os.environ["DEFAULT_MODEL"] == "gpt-4o-mini"
+    assert os.environ["OPENAI_BASE_URL"] == "https://example/v1"
+    assert os.environ["OPENAI_ORGANIZATION"] == "org-42"
+    assert (
+        config_manager._recorded_set_key[(config_manager._env_path, "DEFAULT_MODEL")]
+        == "gpt-4o-mini"
+    )
+
+
+def test_set_openai_llm_settings_clears_optional_fields(config_manager):
+    config_manager.set_openai_llm_settings(
+        model="gpt-4o",
+        base_url="  ",
+        organization="",
+    )
+
+    stored = config_manager.config["OPENAI_LLM"]
+    assert stored["base_url"] is None
+    assert stored["organization"] is None
+    assert "OPENAI_BASE_URL" not in os.environ
+    assert "OPENAI_ORGANIZATION" not in os.environ

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -2,6 +2,271 @@ import asyncio
 import sys
 import types
 
+if "gi" not in sys.modules:
+    gi_stub = types.ModuleType("gi")
+
+    def _require_version(_name, _version):  # pragma: no cover - simple stub
+        return None
+
+    gi_stub.require_version = _require_version
+
+    gtk_module = types.ModuleType("Gtk")
+
+    class _Widget:
+        def __init__(self, *args, **kwargs):
+            self.children = []
+
+        def set_tooltip_text(self, text):
+            self.tooltip_text = text
+
+        def set_hexpand(self, value):
+            self.hexpand = value
+
+        def set_vexpand(self, value):
+            self.vexpand = value
+
+        def set_halign(self, value):
+            self.halign = value
+
+        def set_valign(self, value):
+            self.valign = value
+
+        def set_margin_top(self, value):
+            self.margin_top = value
+
+        def set_margin_bottom(self, value):
+            self.margin_bottom = value
+
+        def set_margin_start(self, value):
+            self.margin_start = value
+
+        def set_margin_end(self, value):
+            self.margin_end = value
+
+    class Window(_Widget):
+        def __init__(self, title=""):
+            super().__init__()
+            self.title = title
+            self.child = None
+            self.modal = False
+            self.presented = False
+            self.closed = False
+
+        def set_transient_for(self, parent):
+            self.transient_for = parent
+
+        def set_modal(self, modal):
+            self.modal = modal
+
+        def set_default_size(self, width, height):
+            self.default_size = (width, height)
+
+        def set_child(self, child):
+            self.child = child
+
+        def present(self):
+            self.presented = True
+
+        def close(self):
+            self.closed = True
+
+    class Box(_Widget):
+        def __init__(self, orientation=None, spacing=0):
+            super().__init__()
+            self.orientation = orientation
+            self.spacing = spacing
+
+        def append(self, child):
+            self.children.append(child)
+
+    class Grid(_Widget):
+        def __init__(self, column_spacing=0, row_spacing=0):
+            super().__init__()
+            self.column_spacing = column_spacing
+            self.row_spacing = row_spacing
+            self.attachments = []
+
+        def attach(self, child, column, row, width, height):
+            self.attachments.append((child, column, row, width, height))
+            self.children.append(child)
+
+    class Label(_Widget):
+        def __init__(self, label=""):
+            super().__init__()
+            self.label = label
+
+        def set_xalign(self, value):
+            self.xalign = value
+
+        def set_yalign(self, value):
+            self.yalign = value
+
+    class ComboBoxText(_Widget):
+        def __init__(self):
+            super().__init__()
+            self._items = []
+            self._active = -1
+
+        def append_text(self, text):
+            self._items.append(text)
+
+        def remove_all(self):
+            self._items = []
+            self._active = -1
+
+        def set_active(self, index):
+            if 0 <= index < len(self._items):
+                self._active = index
+
+        def get_active_text(self):
+            if 0 <= self._active < len(self._items):
+                return self._items[self._active]
+            return None
+
+    class Adjustment:
+        def __init__(self, value=0.0, lower=0.0, upper=1.0, step_increment=0.1, page_increment=0.1):
+            self.value = value
+            self.lower = lower
+            self.upper = upper
+            self.step_increment = step_increment
+            self.page_increment = page_increment
+
+    class SpinButton(_Widget):
+        def __init__(self, adjustment=None, digits=0):
+            super().__init__()
+            self.adjustment = adjustment or Adjustment()
+            self.digits = digits
+            self.value = self.adjustment.value
+
+        def set_increments(self, step, page):
+            self.step_increment = step
+            self.page_increment = page
+
+        def set_value(self, value):
+            self.value = value
+
+        def get_value(self):
+            return self.value
+
+        def get_value_as_int(self):
+            return int(round(self.value))
+
+    class CheckButton(_Widget):
+        def __init__(self, label=""):
+            super().__init__()
+            self.label = label
+            self.active = False
+
+        def set_active(self, value):
+            self.active = bool(value)
+
+        def get_active(self):
+            return self.active
+
+    class Entry(_Widget):
+        def __init__(self):
+            super().__init__()
+            self.text = ""
+            self.placeholder = ""
+
+        def set_text(self, text):
+            self.text = text
+
+        def get_text(self):
+            return self.text
+
+        def set_placeholder_text(self, text):
+            self.placeholder = text
+
+    class Button(_Widget):
+        def __init__(self, label=""):
+            super().__init__()
+            self.label = label
+            self._handlers = {}
+
+        def connect(self, signal, callback):
+            self._handlers.setdefault(signal, []).append(callback)
+
+    class MessageType:
+        ERROR = "error"
+        INFO = "info"
+
+    class ButtonsType:
+        OK = "ok"
+
+    class MessageDialog(Window):
+        def __init__(self, transient_for=None, modal=False, message_type=None, buttons=None, text=""):
+            super().__init__(title=text)
+            self.transient_for = transient_for
+            self.modal = modal
+            self.message_type = message_type
+            self.buttons = buttons
+            self.secondary_text = ""
+
+        def set_secondary_text(self, text):
+            self.secondary_text = text
+
+        def connect(self, signal, callback):
+            if signal == "response":
+                self._response_handler = callback
+
+        def present(self):
+            self.presented = True
+
+    class Orientation:
+        VERTICAL = "vertical"
+        HORIZONTAL = "horizontal"
+
+    class Align:
+        START = "start"
+        END = "end"
+
+    class AccessibleRole:
+        BUTTON = "button"
+
+    class PolicyType:
+        AUTOMATIC = "automatic"
+        NEVER = "never"
+
+    gtk_module.Window = Window
+    gtk_module.Box = Box
+    gtk_module.Grid = Grid
+    gtk_module.Label = Label
+    gtk_module.ComboBoxText = ComboBoxText
+    gtk_module.Adjustment = Adjustment
+    gtk_module.SpinButton = SpinButton
+    gtk_module.CheckButton = CheckButton
+    gtk_module.Entry = Entry
+    gtk_module.Button = Button
+    gtk_module.MessageDialog = MessageDialog
+    gtk_module.MessageType = MessageType
+    gtk_module.ButtonsType = ButtonsType
+    gtk_module.Orientation = Orientation
+    gtk_module.Align = Align
+    gtk_module.AccessibleRole = AccessibleRole
+    gtk_module.PolicyType = PolicyType
+
+    repository_module = types.ModuleType("gi.repository")
+    repository_module.Gtk = gtk_module
+
+    glib_module = types.ModuleType("GLib")
+
+    def idle_add(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    glib_module.idle_add = idle_add
+    repository_module.GLib = glib_module
+
+    gdk_module = types.ModuleType("Gdk")
+    repository_module.Gdk = gdk_module
+
+    sys.modules["gi"] = gi_stub
+    sys.modules["gi"].repository = repository_module
+    sys.modules["gi.repository"] = repository_module
+    sys.modules["gi.repository.Gtk"] = gtk_module
+    sys.modules["gi.repository.GLib"] = glib_module
+    sys.modules["gi.repository.Gdk"] = gdk_module
+
 if "tenacity" not in sys.modules:
     tenacity_stub = types.ModuleType("tenacity")
 
@@ -132,6 +397,7 @@ import pytest
 
 import ATLAS.provider_manager as provider_manager_module
 from ATLAS.provider_manager import ProviderManager
+from GTKUI.Provider_manager.Settings.OA_settings import OpenAISettingsWindow
 
 
 class DummyConfig:
@@ -139,9 +405,44 @@ class DummyConfig:
         self._root_path = root_path
         self._hf_token = ""
         self._api_keys = {}
+        self._default_model = "gpt-4o"
+        self._openai_settings = {
+            "model": "gpt-4o",
+            "temperature": 0.0,
+            "max_tokens": 4000,
+            "stream": True,
+            "base_url": None,
+            "organization": None,
+        }
 
     def get_default_provider(self):
         return "OpenAI"
+
+    def get_openai_llm_settings(self):
+        return dict(self._openai_settings)
+
+    def set_openai_llm_settings(
+        self,
+        *,
+        model,
+        temperature=None,
+        max_tokens=None,
+        stream=None,
+        base_url=None,
+        organization=None,
+    ):
+        if model:
+            self._openai_settings["model"] = model
+            self._default_model = model
+        if temperature is not None:
+            self._openai_settings["temperature"] = float(temperature)
+        if max_tokens is not None:
+            self._openai_settings["max_tokens"] = int(max_tokens)
+        if stream is not None:
+            self._openai_settings["stream"] = bool(stream)
+        self._openai_settings["base_url"] = base_url
+        self._openai_settings["organization"] = organization
+        return dict(self._openai_settings)
 
     def get_app_root(self):
         return self._root_path
@@ -479,3 +780,69 @@ def test_get_provider_api_key_status_with_saved_key(provider_manager):
     assert metadata["length"] == len("sk-test")
     assert metadata["hint"] == "\u2022" * len("sk-test")
     assert metadata["source"] == "environment"
+
+
+def test_set_openai_llm_settings_updates_provider_state(provider_manager):
+    result = provider_manager.set_openai_llm_settings(
+        model="gpt-4o-mini",
+        temperature=0.6,
+        max_tokens=1024,
+        stream=False,
+        base_url="https://example/v1",
+        organization="org-99",
+    )
+
+    assert result["success"] is True
+    settings = provider_manager.get_openai_llm_settings()
+    assert settings["model"] == "gpt-4o-mini"
+    assert settings["stream"] is False
+    assert provider_manager.model_manager.models["OpenAI"][0] == "gpt-4o-mini"
+    assert provider_manager.current_model == "gpt-4o-mini"
+
+
+def test_openai_settings_window_populates_defaults_and_saves(provider_manager):
+    atlas_stub = types.SimpleNamespace()
+
+    saved_payload = {}
+
+    def fake_set_openai_llm_settings(**kwargs):
+        saved_payload.update(kwargs)
+        return {"success": True, "message": "saved"}
+
+    atlas_stub.provider_manager = provider_manager
+    atlas_stub.set_openai_llm_settings = fake_set_openai_llm_settings
+    atlas_stub.get_openai_llm_settings = lambda: {
+        "model": "gpt-4o-mini",
+        "temperature": 0.65,
+        "max_tokens": 2048,
+        "stream": False,
+        "base_url": "https://example/v1",
+        "organization": "org-42",
+    }
+
+    window = OpenAISettingsWindow(atlas_stub, provider_manager.config_manager, None)
+
+    assert window.model_combo.get_active_text() == "gpt-4o-mini"
+    assert window.temperature_spin.get_value() == 0.65
+    assert window.max_tokens_spin.get_value_as_int() == 2048
+    assert window.stream_toggle.get_active() is False
+    assert window.base_url_entry.get_text() == "https://example/v1"
+    assert window.organization_entry.get_text() == "org-42"
+
+    window.model_combo.set_active(1)
+    window.temperature_spin.set_value(0.5)
+    window.max_tokens_spin.set_value(4096)
+    window.stream_toggle.set_active(True)
+    window.base_url_entry.set_text("https://new")
+    window.organization_entry.set_text("org-new")
+
+    window.on_save_clicked(window.model_combo)
+
+    assert saved_payload["model"] == "gpt-4o"
+    assert saved_payload["temperature"] == 0.5
+    assert saved_payload["max_tokens"] == 4096
+    assert saved_payload["stream"] is True
+    assert saved_payload["base_url"] == "https://new"
+    assert saved_payload["organization"] == "org-new"
+    assert window._last_message[0] == "Success"
+    assert window.closed is True


### PR DESCRIPTION
## Summary
- add a dedicated OpenAI settings window with default model, sampling, streaming, and endpoint controls
- extend the configuration and provider layers to persist and apply OpenAI LLM defaults, including base URL and organization
- teach the OpenAI generator to honour stored defaults and add regression coverage for the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0a88c82fc832292f27565dd02ed20