### PR TITLE
Restore OpenAI API key field in settings

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -433,6 +433,43 @@ class ATLAS:
         """
         return self.provider_manager.get_current_model()
 
+    def get_openai_llm_settings(self) -> Dict[str, Any]:
+        """Expose the persisted OpenAI LLM defaults."""
+
+        provider_manager = getattr(self, "provider_manager", None)
+        if provider_manager is not None:
+            getter = getattr(provider_manager, "get_openai_llm_settings", None)
+            if callable(getter):
+                return getter()
+
+        return self.config_manager.get_openai_llm_settings()
+
+    def set_openai_llm_settings(
+        self,
+        *,
+        model: str,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stream: Optional[bool] = None,
+        api_key: Optional[str] = None,
+        organization: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Persist OpenAI defaults through the provider manager facade."""
+
+        manager = self._require_provider_manager()
+        setter = getattr(manager, "set_openai_llm_settings", None)
+        if not callable(setter):
+            raise AttributeError("Provider manager does not support OpenAI settings updates.")
+
+        return setter(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=stream,
+            api_key=api_key,
+            organization=organization,
+        )
+
     def get_chat_status_summary(self) -> Dict[str, str]:
         """Return a consolidated snapshot of chat-related status information."""
 

--- a/ATLAS/provider_manager.py
+++ b/ATLAS/provider_manager.py
@@ -146,6 +146,61 @@ class ProviderManager:
         self.logger.info("API key for %s updated via provider manager.", provider_name)
         return self._build_result(True, message=message)
 
+    def set_openai_llm_settings(
+        self,
+        *,
+        model: Optional[str],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stream: Optional[bool] = None,
+        api_key: Optional[str] = None,
+        organization: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Persist OpenAI LLM defaults via the config manager and refresh runtime state."""
+
+        try:
+            settings = self.config_manager.set_openai_llm_settings(
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                stream=stream,
+                api_key=api_key,
+                organization=organization,
+            )
+        except Exception as exc:
+            self.logger.error("Failed to persist OpenAI settings: %s", exc, exc_info=True)
+            return self._build_result(False, error=str(exc))
+
+        promoted_model = settings.get("model")
+        if promoted_model:
+            with self.model_manager.lock:
+                available = list(self.model_manager.models.get("OpenAI", []))
+                new_order = [promoted_model] + [name for name in available if name != promoted_model]
+                self.model_manager.models["OpenAI"] = new_order
+            self.model_manager.set_model(promoted_model, "OpenAI")
+            if self.current_llm_provider == "OpenAI":
+                self.current_model = promoted_model
+
+        message = "OpenAI settings saved."
+        refreshed = self.get_openai_llm_settings()
+        return self._build_result(True, message=message, data=refreshed)
+
+    def get_openai_llm_settings(self) -> Dict[str, Any]:
+        """Return configured OpenAI defaults or an empty payload on failure."""
+
+        getter = getattr(self.config_manager, "get_openai_llm_settings", None)
+        if not callable(getter):
+            self.logger.warning("Config manager does not expose OpenAI settings accessor.")
+            return {}
+
+        try:
+            settings = getter() or {}
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.logger.error("Failed to load OpenAI settings: %s", exc, exc_info=True)
+            return {}
+
+        return settings
+
     @staticmethod
     def _mask_secret(secret: str) -> str:
         """Return a sanitized preview for a stored secret without leaking its value."""
@@ -629,9 +684,9 @@ class ProviderManager:
         messages: List[Dict[str, str]],
         model: str = None,
         provider: str = None,
-        max_tokens: int = 4000,
-        temperature: float = 0.0,
-        stream: bool = True,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stream: Optional[bool] = None,
         current_persona=None,
         functions=None,
         llm_call_type: str = None
@@ -643,9 +698,9 @@ class ProviderManager:
             messages (List[Dict[str, str]]): The conversation messages.
             model (str, optional): The model to use. If None, uses the current model.
             provider (str, optional): The provider to use. If None, uses the current provider.
-            max_tokens (int, optional): Maximum number of tokens. Defaults to 4000.
-            temperature (float, optional): Sampling temperature. Defaults to 0.0.
-            stream (bool, optional): Whether to stream the response. Defaults to True.
+            max_tokens (int, optional): Maximum number of tokens. Uses saved default when omitted.
+            temperature (float, optional): Sampling temperature. Uses saved default when omitted.
+            stream (bool, optional): Whether to stream the response. Uses saved default when omitted.
             current_persona (optional): The current persona.
             functions (optional): Functions to use.
             llm_call_type (str, optional): The type of LLM call.
@@ -655,25 +710,51 @@ class ProviderManager:
         """
         # Determine provider and model
         requested_provider = provider if provider else self.current_llm_provider
-        requested_model = model if model else self.get_current_model()
+        if not requested_provider:
+            requested_provider = self.config_manager.get_default_provider()
+
+        defaults: Dict[str, Any] = {}
+        if requested_provider == "OpenAI":
+            defaults = self.get_openai_llm_settings()
+
+        resolved_model = model or defaults.get("model") or self.get_current_model()
+        if not resolved_model:
+            fallback_model = self.get_default_model_for_provider(requested_provider)
+            resolved_model = fallback_model
+
+        resolved_max_tokens = max_tokens if max_tokens is not None else defaults.get("max_tokens", 4000)
+        resolved_temperature = (
+            temperature if temperature is not None else defaults.get("temperature", 0.0)
+        )
+        resolved_stream = stream if stream is not None else defaults.get("stream", True)
 
         # Log the incoming parameters
-        self.logger.info(f"Generating response with Provider: {requested_provider}, Model: {requested_model}, Persona: {current_persona}")
+        self.logger.info(
+            "Generating response with Provider: %s, Model: %s, Persona: %s",
+            requested_provider,
+            resolved_model,
+            current_persona,
+        )
 
         # Switch provider if different
         if requested_provider != self.current_llm_provider:
             await self.switch_llm_provider(requested_provider)
 
         # Switch model if different
-        if requested_model != self.current_model:
-            await self.set_model(requested_model)
+        if resolved_model and resolved_model != self.current_model:
+            await self.set_model(resolved_model)
 
         # Use current functions if not provided
         if functions is None:
             functions = self.current_functions
 
         start_time = time.time()
-        self.logger.info(f"Starting API call to {requested_provider} with model {requested_model} for {llm_call_type}")
+        self.logger.info(
+            "Starting API call to %s with model %s for %s",
+            requested_provider,
+            resolved_model,
+            llm_call_type,
+        )
 
         try:
             if not self.generate_response_func:
@@ -683,10 +764,10 @@ class ProviderManager:
             response = await self.generate_response_func(
                 self.config_manager,
                 messages=messages,
-                model=requested_model,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                stream=stream,
+                model=resolved_model,
+                max_tokens=resolved_max_tokens,
+                temperature=resolved_temperature,
+                stream=resolved_stream,
                 current_persona=current_persona,
                 functions=functions
             )

--- a/GTKUI/Provider_manager/Settings/OA_settings.py
+++ b/GTKUI/Provider_manager/Settings/OA_settings.py
@@ -1,0 +1,229 @@
+"""Dedicated GTK window for configuring OpenAI provider defaults."""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk, GLib
+
+from GTKUI.Utils.utils import create_box
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAISettingsWindow(Gtk.Window):
+    """Collect OpenAI-specific preferences such as default model and streaming mode."""
+
+    def __init__(self, ATLAS, config_manager, parent_window):
+        super().__init__(title="OpenAI Settings")
+        self.ATLAS = ATLAS
+        self.config_manager = config_manager
+        self.parent_window = parent_window
+        if parent_window is not None:
+            self.set_transient_for(parent_window)
+        self.set_modal(True)
+        self.set_default_size(420, 320)
+
+        self._last_message: Optional[Tuple[str, str, Gtk.MessageType]] = None
+
+        main_box = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=12, margin=12)
+        self.set_child(main_box)
+
+        grid = Gtk.Grid(column_spacing=12, row_spacing=8)
+        main_box.append(grid)
+
+        row = 0
+        model_label = Gtk.Label(label="Default Model:")
+        model_label.set_xalign(0.0)
+        grid.attach(model_label, 0, row, 1, 1)
+        self.model_combo = Gtk.ComboBoxText()
+        self.model_combo.set_hexpand(True)
+        grid.attach(self.model_combo, 1, row, 1, 1)
+
+        row += 1
+        temp_label = Gtk.Label(label="Temperature:")
+        temp_label.set_xalign(0.0)
+        grid.attach(temp_label, 0, row, 1, 1)
+        self.temperature_adjustment = Gtk.Adjustment(lower=0.0, upper=2.0, step_increment=0.05, page_increment=0.1, value=0.0)
+        self.temperature_spin = Gtk.SpinButton(adjustment=self.temperature_adjustment, digits=2)
+        self.temperature_spin.set_increments(0.05, 0.1)
+        self.temperature_spin.set_hexpand(True)
+        grid.attach(self.temperature_spin, 1, row, 1, 1)
+
+        row += 1
+        tokens_label = Gtk.Label(label="Max Tokens:")
+        tokens_label.set_xalign(0.0)
+        grid.attach(tokens_label, 0, row, 1, 1)
+        self.max_tokens_adjustment = Gtk.Adjustment(lower=1, upper=128000, step_increment=128, page_increment=512, value=4000)
+        self.max_tokens_spin = Gtk.SpinButton(adjustment=self.max_tokens_adjustment, digits=0)
+        self.max_tokens_spin.set_increments(128, 512)
+        self.max_tokens_spin.set_hexpand(True)
+        grid.attach(self.max_tokens_spin, 1, row, 1, 1)
+
+        row += 1
+        self.stream_toggle = Gtk.CheckButton(label="Enable streaming responses")
+        self.stream_toggle.set_halign(Gtk.Align.START)
+        grid.attach(self.stream_toggle, 0, row, 2, 1)
+
+        row += 1
+        api_key_label = Gtk.Label(label="API Key:")
+        api_key_label.set_xalign(0.0)
+        grid.attach(api_key_label, 0, row, 1, 1)
+        self.api_key_entry = Gtk.Entry()
+        self.api_key_entry.set_hexpand(True)
+        self.api_key_entry.set_placeholder_text("sk-...")
+        self.api_key_entry.set_visibility(False)
+        grid.attach(self.api_key_entry, 1, row, 1, 1)
+
+        row += 1
+        self.api_key_toggle = Gtk.CheckButton(label="Show API key")
+        self.api_key_toggle.set_halign(Gtk.Align.START)
+        self.api_key_toggle.connect("toggled", self._on_api_key_toggle)
+        grid.attach(self.api_key_toggle, 0, row, 2, 1)
+
+        row += 1
+        org_label = Gtk.Label(label="Organization (optional):")
+        org_label.set_xalign(0.0)
+        grid.attach(org_label, 0, row, 1, 1)
+        self.organization_entry = Gtk.Entry()
+        self.organization_entry.set_hexpand(True)
+        self.organization_entry.set_placeholder_text("org-1234")
+        grid.attach(self.organization_entry, 1, row, 1, 1)
+
+        button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        button_box.set_halign(Gtk.Align.END)
+        main_box.append(button_box)
+
+        cancel_button = Gtk.Button(label="Cancel")
+        cancel_button.connect("clicked", lambda *_: self.close())
+        button_box.append(cancel_button)
+
+        save_button = Gtk.Button(label="Save Settings")
+        save_button.connect("clicked", self.on_save_clicked)
+        button_box.append(save_button)
+
+        self._populate_defaults()
+
+    def _populate_defaults(self) -> None:
+        settings = self._get_settings_snapshot()
+        models = self._load_available_models()
+
+        self.model_combo.remove_all()
+        if settings.get("model") and settings["model"] not in models:
+            models = [settings["model"]] + [name for name in models if name != settings["model"]]
+
+        if not models:
+            models = [settings.get("model") or "gpt-4o"]
+
+        active_index = 0
+        for idx, name in enumerate(models):
+            self.model_combo.append_text(name)
+            if name == settings.get("model"):
+                active_index = idx
+        self.model_combo.set_active(active_index)
+
+        self.temperature_spin.set_value(float(settings.get("temperature", 0.0)))
+        self.max_tokens_spin.set_value(float(settings.get("max_tokens", 4000)))
+        self.stream_toggle.set_active(bool(settings.get("stream", True)))
+        self.api_key_entry.set_text(self._get_api_key_snapshot())
+        self.api_key_toggle.set_active(False)
+        self.organization_entry.set_text(settings.get("organization") or "")
+
+    def _get_settings_snapshot(self) -> Dict[str, Any]:
+        try:
+            if hasattr(self.ATLAS, "get_openai_llm_settings"):
+                return dict(self.ATLAS.get_openai_llm_settings() or {})
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to read OpenAI settings from ATLAS: %s", exc, exc_info=True)
+
+        try:
+            return dict(self.config_manager.get_openai_llm_settings() or {})
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to read OpenAI settings from config manager: %s", exc, exc_info=True)
+            return {}
+
+    def _get_api_key_snapshot(self) -> str:
+        try:
+            getter = getattr(self.config_manager, "get_openai_api_key", None)
+            if callable(getter):
+                return getter() or ""
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to read OpenAI API key: %s", exc, exc_info=True)
+        return ""
+
+    def _load_available_models(self) -> List[str]:
+        provider_manager = getattr(self.ATLAS, "provider_manager", None)
+        if provider_manager and getattr(provider_manager, "model_manager", None):
+            try:
+                payload = provider_manager.model_manager.get_available_models("OpenAI")
+                models = payload.get("OpenAI", [])
+                if isinstance(models, list):
+                    return list(models)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error("Failed to load OpenAI model list: %s", exc, exc_info=True)
+        return []
+
+    def on_save_clicked(self, _button: Gtk.Button):
+        model = self.model_combo.get_active_text()
+        if not model:
+            self._show_message("Error", "Please choose a default model before saving.", Gtk.MessageType.ERROR)
+            return
+
+        payload = {
+            "model": model,
+            "temperature": self.temperature_spin.get_value(),
+            "max_tokens": self.max_tokens_spin.get_value_as_int(),
+            "stream": self.stream_toggle.get_active(),
+            "api_key": self.api_key_entry.get_text().strip() or None,
+            "organization": self.organization_entry.get_text().strip() or None,
+        }
+
+        try:
+            result = self.ATLAS.set_openai_llm_settings(**payload)
+        except Exception as exc:
+            logger.error("Error saving OpenAI settings: %s", exc, exc_info=True)
+            self._show_message("Error", str(exc), Gtk.MessageType.ERROR)
+            return
+
+        if isinstance(result, dict) and result.get("success"):
+            message = result.get("message", "OpenAI settings saved.")
+            self._show_message("Success", message, Gtk.MessageType.INFO)
+            self.close()
+            return
+
+        if isinstance(result, dict):
+            detail = result.get("error") or result.get("message") or "Unable to save OpenAI settings."
+        elif result is None:
+            detail = "Unable to save OpenAI settings."
+        else:
+            detail = str(result)
+
+        self._show_message("Error", detail, Gtk.MessageType.ERROR)
+
+    def _show_message(self, title: str, message: str, message_type: Gtk.MessageType):
+        self._last_message = (title, message, message_type)
+
+        try:
+            dialog = Gtk.MessageDialog(
+                transient_for=self,
+                modal=True,
+                message_type=message_type,
+                buttons=Gtk.ButtonsType.OK,
+                text=title,
+            )
+        except Exception:  # pragma: no cover - fallback when running in stubbed environments
+            logger.debug("GTK message dialog unavailable; skipping display for '%s'.", title)
+            return
+
+        if hasattr(dialog, "set_secondary_text"):
+            dialog.set_secondary_text(message)
+        else:
+            dialog.props.secondary_text = message
+
+        dialog.connect("response", lambda dlg, *_: dlg.destroy())
+        GLib.idle_add(dialog.present)
+
+    def _on_api_key_toggle(self, toggle: Gtk.CheckButton):
+        self.api_key_entry.set_visibility(toggle.get_active())

--- a/GTKUI/Provider_manager/provider_management.py
+++ b/GTKUI/Provider_manager/provider_management.py
@@ -12,6 +12,7 @@ import logging
 
 from GTKUI.Utils.utils import create_box
 from .Settings.HF_settings import HuggingFaceSettingsWindow
+from .Settings.OA_settings import OpenAISettingsWindow
 
 class ProviderManagement:
     """
@@ -168,7 +169,9 @@ class ProviderManagement:
         if self.provider_window:
             GLib.idle_add(self.provider_window.close)
 
-        if provider_name == "HuggingFace":
+        if provider_name == "OpenAI":
+            self.show_openai_settings()
+        elif provider_name == "HuggingFace":
             try:
                 result = self.ATLAS.ensure_huggingface_ready()
             except AttributeError:
@@ -197,6 +200,13 @@ class ProviderManagement:
             self.show_huggingface_settings()
         else:
             self.show_provider_settings(provider_name)
+
+    def show_openai_settings(self):
+        """Display the OpenAI provider configuration dialog."""
+
+        settings_window = OpenAISettingsWindow(self.ATLAS, self.config_manager, self.parent_window)
+        settings_window.set_tooltip_text("Configure OpenAI defaults and credentials.")
+        settings_window.present()
 
     def show_huggingface_settings(self):
         """

--- a/modules/Providers/OpenAI/OA_gen_response.py
+++ b/modules/Providers/OpenAI/OA_gen_response.py
@@ -4,7 +4,7 @@ from openai import AsyncOpenAI
 from ATLAS.model_manager import ModelManager
 
 from tenacity import retry, stop_after_attempt, wait_exponential
-from typing import List, Dict, Union, AsyncIterator
+from typing import List, Dict, Union, AsyncIterator, Optional
 from ATLAS.config import ConfigManager
 from modules.logging.logger import setup_logger
 from ATLAS.ToolManager import (
@@ -21,17 +21,26 @@ class OpenAIGenerator:
         if not self.api_key:
             self.logger.error("OpenAI API key not found in configuration")
             raise ValueError("OpenAI API key not found in configuration")
-        self.client = AsyncOpenAI(api_key=self.api_key)
-        self.model_manager = ModelManager(config_manager)  
+        settings = self.config_manager.get_openai_llm_settings()
+        client_kwargs = {"api_key": self.api_key}
+        organization = settings.get("organization")
+        if organization:
+            client_kwargs["organization"] = organization
+
+        self.client = AsyncOpenAI(**client_kwargs)
+        self.model_manager = ModelManager(config_manager)
+        default_model = settings.get("model")
+        if default_model:
+            self.model_manager.set_model(default_model, "OpenAI")
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10))
     async def generate_response(
         self,
         messages: List[Dict[str, str]],
         model: str = None,
-        max_tokens: int = 4000,
-        temperature: float = 0.0,
-        stream: bool = True,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stream: Optional[bool] = None,
         current_persona=None,
         conversation_manager=None,
         user=None,
@@ -39,15 +48,26 @@ class OpenAIGenerator:
         functions=None
     ) -> Union[str, AsyncIterator[str]]:
         try:
+            settings = self.config_manager.get_openai_llm_settings()
             current_model = self.model_manager.get_current_model()
-            
+
             if model and model != current_model:
                 self.model_manager.set_model(model, "OpenAI")
                 current_model = model
                 self.logger.info(f"Model changed to {model}")
             elif not model:
-                model = current_model
+                model = settings.get("model") or current_model
+                if model and model != current_model:
+                    self.model_manager.set_model(model, "OpenAI")
+                    current_model = model
                 self.logger.info(f"Using current model: {model}")
+
+            if max_tokens is None:
+                max_tokens = int(settings.get("max_tokens", 4000))
+            if temperature is None:
+                temperature = float(settings.get("temperature", 0.0))
+            if stream is None:
+                stream = bool(settings.get("stream", True))
 
             self.logger.info(f"Starting API call to OpenAI with model {model}")
             self.logger.info(f"Current persona: {current_persona}")

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -2,6 +2,279 @@ import asyncio
 import sys
 import types
 
+if "gi" not in sys.modules:
+    gi_stub = types.ModuleType("gi")
+
+    def _require_version(_name, _version):  # pragma: no cover - simple stub
+        return None
+
+    gi_stub.require_version = _require_version
+
+    gtk_module = types.ModuleType("Gtk")
+
+    class _Widget:
+        def __init__(self, *args, **kwargs):
+            self.children = []
+
+        def set_tooltip_text(self, text):
+            self.tooltip_text = text
+
+        def set_hexpand(self, value):
+            self.hexpand = value
+
+        def set_vexpand(self, value):
+            self.vexpand = value
+
+        def set_halign(self, value):
+            self.halign = value
+
+        def set_valign(self, value):
+            self.valign = value
+
+        def set_margin_top(self, value):
+            self.margin_top = value
+
+        def set_margin_bottom(self, value):
+            self.margin_bottom = value
+
+        def set_margin_start(self, value):
+            self.margin_start = value
+
+        def set_margin_end(self, value):
+            self.margin_end = value
+
+    class Window(_Widget):
+        def __init__(self, title=""):
+            super().__init__()
+            self.title = title
+            self.child = None
+            self.modal = False
+            self.presented = False
+            self.closed = False
+
+        def set_transient_for(self, parent):
+            self.transient_for = parent
+
+        def set_modal(self, modal):
+            self.modal = modal
+
+        def set_default_size(self, width, height):
+            self.default_size = (width, height)
+
+        def set_child(self, child):
+            self.child = child
+
+        def present(self):
+            self.presented = True
+
+        def close(self):
+            self.closed = True
+
+    class Box(_Widget):
+        def __init__(self, orientation=None, spacing=0):
+            super().__init__()
+            self.orientation = orientation
+            self.spacing = spacing
+
+        def append(self, child):
+            self.children.append(child)
+
+    class Grid(_Widget):
+        def __init__(self, column_spacing=0, row_spacing=0):
+            super().__init__()
+            self.column_spacing = column_spacing
+            self.row_spacing = row_spacing
+            self.attachments = []
+
+        def attach(self, child, column, row, width, height):
+            self.attachments.append((child, column, row, width, height))
+            self.children.append(child)
+
+    class Label(_Widget):
+        def __init__(self, label=""):
+            super().__init__()
+            self.label = label
+
+        def set_xalign(self, value):
+            self.xalign = value
+
+        def set_yalign(self, value):
+            self.yalign = value
+
+    class ComboBoxText(_Widget):
+        def __init__(self):
+            super().__init__()
+            self._items = []
+            self._active = -1
+
+        def append_text(self, text):
+            self._items.append(text)
+
+        def remove_all(self):
+            self._items = []
+            self._active = -1
+
+        def set_active(self, index):
+            if 0 <= index < len(self._items):
+                self._active = index
+
+        def get_active_text(self):
+            if 0 <= self._active < len(self._items):
+                return self._items[self._active]
+            return None
+
+    class Adjustment:
+        def __init__(self, value=0.0, lower=0.0, upper=1.0, step_increment=0.1, page_increment=0.1):
+            self.value = value
+            self.lower = lower
+            self.upper = upper
+            self.step_increment = step_increment
+            self.page_increment = page_increment
+
+    class SpinButton(_Widget):
+        def __init__(self, adjustment=None, digits=0):
+            super().__init__()
+            self.adjustment = adjustment or Adjustment()
+            self.digits = digits
+            self.value = self.adjustment.value
+
+        def set_increments(self, step, page):
+            self.step_increment = step
+            self.page_increment = page
+
+        def set_value(self, value):
+            self.value = value
+
+        def get_value(self):
+            return self.value
+
+        def get_value_as_int(self):
+            return int(round(self.value))
+
+    class CheckButton(_Widget):
+        def __init__(self, label=""):
+            super().__init__()
+            self.label = label
+            self.active = False
+            self._handlers = {}
+
+        def set_active(self, value):
+            self.active = bool(value)
+
+        def get_active(self):
+            return self.active
+
+        def connect(self, signal, callback):
+            self._handlers.setdefault(signal, []).append(callback)
+
+    class Entry(_Widget):
+        def __init__(self):
+            super().__init__()
+            self.text = ""
+            self.placeholder = ""
+            self.visible = True
+
+        def set_text(self, text):
+            self.text = text
+
+        def get_text(self):
+            return self.text
+
+        def set_placeholder_text(self, text):
+            self.placeholder = text
+
+        def set_visibility(self, value):
+            self.visible = bool(value)
+
+    class Button(_Widget):
+        def __init__(self, label=""):
+            super().__init__()
+            self.label = label
+            self._handlers = {}
+
+        def connect(self, signal, callback):
+            self._handlers.setdefault(signal, []).append(callback)
+
+    class MessageType:
+        ERROR = "error"
+        INFO = "info"
+
+    class ButtonsType:
+        OK = "ok"
+
+    class MessageDialog(Window):
+        def __init__(self, transient_for=None, modal=False, message_type=None, buttons=None, text=""):
+            super().__init__(title=text)
+            self.transient_for = transient_for
+            self.modal = modal
+            self.message_type = message_type
+            self.buttons = buttons
+            self.secondary_text = ""
+
+        def set_secondary_text(self, text):
+            self.secondary_text = text
+
+        def connect(self, signal, callback):
+            if signal == "response":
+                self._response_handler = callback
+
+        def present(self):
+            self.presented = True
+
+    class Orientation:
+        VERTICAL = "vertical"
+        HORIZONTAL = "horizontal"
+
+    class Align:
+        START = "start"
+        END = "end"
+
+    class AccessibleRole:
+        BUTTON = "button"
+
+    class PolicyType:
+        AUTOMATIC = "automatic"
+        NEVER = "never"
+
+    gtk_module.Window = Window
+    gtk_module.Box = Box
+    gtk_module.Grid = Grid
+    gtk_module.Label = Label
+    gtk_module.ComboBoxText = ComboBoxText
+    gtk_module.Adjustment = Adjustment
+    gtk_module.SpinButton = SpinButton
+    gtk_module.CheckButton = CheckButton
+    gtk_module.Entry = Entry
+    gtk_module.Button = Button
+    gtk_module.MessageDialog = MessageDialog
+    gtk_module.MessageType = MessageType
+    gtk_module.ButtonsType = ButtonsType
+    gtk_module.Orientation = Orientation
+    gtk_module.Align = Align
+    gtk_module.AccessibleRole = AccessibleRole
+    gtk_module.PolicyType = PolicyType
+
+    repository_module = types.ModuleType("gi.repository")
+    repository_module.Gtk = gtk_module
+
+    glib_module = types.ModuleType("GLib")
+
+    def idle_add(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    glib_module.idle_add = idle_add
+    repository_module.GLib = glib_module
+
+    gdk_module = types.ModuleType("Gdk")
+    repository_module.Gdk = gdk_module
+
+    sys.modules["gi"] = gi_stub
+    sys.modules["gi"].repository = repository_module
+    sys.modules["gi.repository"] = repository_module
+    sys.modules["gi.repository.Gtk"] = gtk_module
+    sys.modules["gi.repository.GLib"] = glib_module
+    sys.modules["gi.repository.Gdk"] = gdk_module
+
 if "tenacity" not in sys.modules:
     tenacity_stub = types.ModuleType("tenacity")
 
@@ -132,6 +405,7 @@ import pytest
 
 import ATLAS.provider_manager as provider_manager_module
 from ATLAS.provider_manager import ProviderManager
+from GTKUI.Provider_manager.Settings.OA_settings import OpenAISettingsWindow
 
 
 class DummyConfig:
@@ -139,9 +413,45 @@ class DummyConfig:
         self._root_path = root_path
         self._hf_token = ""
         self._api_keys = {}
+        self._default_model = "gpt-4o"
+        self._openai_settings = {
+            "model": "gpt-4o",
+            "temperature": 0.0,
+            "max_tokens": 4000,
+            "stream": True,
+            "organization": None,
+        }
+        self._openai_api_key = ""
 
     def get_default_provider(self):
         return "OpenAI"
+
+    def get_openai_llm_settings(self):
+        return dict(self._openai_settings)
+
+    def set_openai_llm_settings(
+        self,
+        *,
+        model,
+        temperature=None,
+        max_tokens=None,
+        stream=None,
+        api_key=None,
+        organization=None,
+    ):
+        if model:
+            self._openai_settings["model"] = model
+            self._default_model = model
+        if temperature is not None:
+            self._openai_settings["temperature"] = float(temperature)
+        if max_tokens is not None:
+            self._openai_settings["max_tokens"] = int(max_tokens)
+        if stream is not None:
+            self._openai_settings["stream"] = bool(stream)
+        self._openai_settings["organization"] = organization
+        if api_key is not None:
+            self._openai_api_key = api_key
+        return dict(self._openai_settings)
 
     def get_app_root(self):
         return self._root_path
@@ -165,7 +475,7 @@ class DummyConfig:
         return self._hf_token
 
     def get_openai_api_key(self):
-        return self._api_keys.get("OpenAI", "")
+        return self._openai_api_key or self._api_keys.get("OpenAI", "")
 
     def set_huggingface_api_key(self, token):
         self.set_hf_token(token)
@@ -479,3 +789,71 @@ def test_get_provider_api_key_status_with_saved_key(provider_manager):
     assert metadata["length"] == len("sk-test")
     assert metadata["hint"] == "\u2022" * len("sk-test")
     assert metadata["source"] == "environment"
+
+
+def test_set_openai_llm_settings_updates_provider_state(provider_manager):
+    result = provider_manager.set_openai_llm_settings(
+        model="gpt-4o-mini",
+        temperature=0.6,
+        max_tokens=1024,
+        stream=False,
+        api_key="sk-live",
+        organization="org-99",
+    )
+
+    assert result["success"] is True
+    settings = provider_manager.get_openai_llm_settings()
+    assert settings["model"] == "gpt-4o-mini"
+    assert settings["stream"] is False
+    assert provider_manager.model_manager.models["OpenAI"][0] == "gpt-4o-mini"
+    assert provider_manager.current_model == "gpt-4o-mini"
+    assert provider_manager.config_manager.get_openai_api_key() == "sk-live"
+
+
+def test_openai_settings_window_populates_defaults_and_saves(provider_manager):
+    atlas_stub = types.SimpleNamespace()
+
+    saved_payload = {}
+
+    def fake_set_openai_llm_settings(**kwargs):
+        saved_payload.update(kwargs)
+        return {"success": True, "message": "saved"}
+
+    atlas_stub.provider_manager = provider_manager
+    atlas_stub.set_openai_llm_settings = fake_set_openai_llm_settings
+    atlas_stub.get_openai_llm_settings = lambda: {
+        "model": "gpt-4o-mini",
+        "temperature": 0.65,
+        "max_tokens": 2048,
+        "stream": False,
+        "organization": "org-42",
+    }
+
+    provider_manager.config_manager._openai_api_key = "sk-stored"
+
+    window = OpenAISettingsWindow(atlas_stub, provider_manager.config_manager, None)
+
+    assert window.model_combo.get_active_text() == "gpt-4o-mini"
+    assert window.temperature_spin.get_value() == 0.65
+    assert window.max_tokens_spin.get_value_as_int() == 2048
+    assert window.stream_toggle.get_active() is False
+    assert window.api_key_entry.get_text() == "sk-stored"
+    assert window.organization_entry.get_text() == "org-42"
+
+    window.model_combo.set_active(1)
+    window.temperature_spin.set_value(0.5)
+    window.max_tokens_spin.set_value(4096)
+    window.stream_toggle.set_active(True)
+    window.api_key_entry.set_text("sk-new")
+    window.organization_entry.set_text("org-new")
+
+    window.on_save_clicked(window.model_combo)
+
+    assert saved_payload["model"] == "gpt-4o"
+    assert saved_payload["temperature"] == 0.5
+    assert saved_payload["max_tokens"] == 4096
+    assert saved_payload["stream"] is True
+    assert saved_payload["api_key"] == "sk-new"
+    assert saved_payload["organization"] == "org-new"
+    assert window._last_message[0] == "Success"
+    assert window.closed is True


### PR DESCRIPTION
## Summary
- replace the OpenAI settings window base URL row with a password-style API key entry and show/hide toggle while still exposing organization metadata
- teach the configuration and provider layers to accept the optional API key when saving OpenAI defaults and propagate the new signature through the ATLAS facade and generator
- refresh OpenAI persistence and GTK/provider manager tests to validate API key handling and UI population without the deprecated base URL field

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0a88c82fc832292f27565dd02ed20