### PR TITLE
Add advanced base URL controls to OpenAI settings

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -137,7 +137,7 @@ def test_set_openai_llm_settings_updates_state(config_manager):
         presence_penalty=-0.5,
         max_tokens=2048,
         stream=False,
-        base_url="https://example/v1",
+        base_url=" https://example/v1 ",
         organization="org-42",
     )
 
@@ -163,6 +163,15 @@ def test_set_openai_llm_settings_updates_state(config_manager):
 
 
 def test_set_openai_llm_settings_clears_optional_fields(config_manager):
+    config_manager.set_openai_llm_settings(
+        model="gpt-4o",
+        base_url="https://custom/v1",
+        organization="org-keep",
+    )
+
+    assert os.environ["OPENAI_BASE_URL"] == "https://custom/v1"
+    assert os.environ["OPENAI_ORGANIZATION"] == "org-keep"
+
     config_manager.set_openai_llm_settings(
         model="gpt-4o",
         base_url="  ",

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -904,6 +904,7 @@ def test_openai_settings_window_populates_defaults_and_saves(provider_manager, m
     window.max_tokens_spin.set_value(4096)
     window.stream_toggle.set_active(True)
     window.organization_entry.set_text("org-new")
+    window.base_url_entry.set_text("https://alt.example/v2")
 
     window.on_save_clicked(window.model_combo)
 
@@ -914,8 +915,9 @@ def test_openai_settings_window_populates_defaults_and_saves(provider_manager, m
     assert saved_payload["presence_penalty"] == -0.15
     assert saved_payload["max_tokens"] == 4096
     assert saved_payload["stream"] is True
-    assert saved_payload["base_url"] == "https://example/v1"
+    assert saved_payload["base_url"] == "https://alt.example/v2"
     assert saved_payload["organization"] == "org-new"
+    assert window._stored_base_url == "https://alt.example/v2"
     assert window._last_message[0] == "Success"
     assert window.closed is True
 


### PR DESCRIPTION
## Summary
- add an advanced settings section to the OpenAI configuration window with a validated base URL entry that feeds save and model refresh flows
- extend configuration tests to cover sanitizing and clearing custom base URLs and ensure the GTK harness persists user-entered overrides

## Testing
- pytest tests/test_config_manager.py tests/test_provider_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d163f80c188322ad79c1befe0ff1ae