### PR TITLE
Expose Google credentials path via speech facade

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -745,6 +745,11 @@ class ATLAS:
 
         self.speech_manager.set_google_credentials(credentials_path)
 
+    def get_google_speech_credentials_path(self) -> Optional[str]:
+        """Return the persisted Google speech credentials path."""
+
+        return self.speech_manager.get_google_credentials_path()
+
     def get_openai_speech_options(self) -> Dict[str, List[Tuple[str, Optional[str]]]]:
         """Return the OpenAI speech option sets for UI rendering."""
 

--- a/GTKUI/Settings/Speech/speech_settings.py
+++ b/GTKUI/Settings/Speech/speech_settings.py
@@ -551,7 +551,20 @@ class SpeechSettings(Gtk.Window):
         self.google_credentials_entry.set_tooltip_text("Enter the absolute path to the Google credentials JSON.")
         self.google_credentials_entry.set_visibility(True)
         self.google_credentials_entry.set_hexpand(True)
-        existing_google_creds = self.ATLAS.config_manager.get_config("GOOGLE_APPLICATION_CREDENTIALS") or ""
+        existing_google_creds = ""
+        getter = getattr(self.ATLAS, "get_google_speech_credentials_path", None)
+        if callable(getter):
+            try:
+                stored_creds = getter()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error(
+                    "Failed to load Google credentials path from façade: %s", exc, exc_info=True
+                )
+            else:
+                if isinstance(stored_creds, str):
+                    existing_google_creds = stored_creds
+                elif stored_creds is not None:
+                    existing_google_creds = str(stored_creds)
         self.google_credentials_entry.set_text(existing_google_creds)
         h.append(self.google_credentials_entry)
 

--- a/modules/Speech_Services/speech_manager.py
+++ b/modules/Speech_Services/speech_manager.py
@@ -366,6 +366,19 @@ class SpeechManager:
         if was_default_stt:
             self.set_default_stt_provider('google')
 
+    def get_google_credentials_path(self) -> Optional[str]:
+        """Return the persisted Google credentials path when available."""
+
+        getter = getattr(self.config_manager, "get_config", None)
+        if callable(getter):
+            return getter("GOOGLE_APPLICATION_CREDENTIALS")
+
+        config = getattr(self.config_manager, "config", {})
+        if isinstance(config, dict):
+            return config.get("GOOGLE_APPLICATION_CREDENTIALS")
+
+        return None
+
     def set_elevenlabs_api_key(self, api_key: str, *, persist: bool = True):
         """Persist the ElevenLabs API key and refresh the provider instance."""
 

--- a/tests/test_speech_manager.py
+++ b/tests/test_speech_manager.py
@@ -781,3 +781,9 @@ def test_set_google_credentials_factory_failure_rolls_back(speech_manager, monke
         speech_manager.set_google_credentials("/tmp/new.json")
 
     assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == "old.json"
+
+
+def test_get_google_credentials_path_reads_config(speech_manager):
+    speech_manager.config_manager.config["GOOGLE_APPLICATION_CREDENTIALS"] = "/tmp/creds.json"
+
+    assert speech_manager.get_google_credentials_path() == "/tmp/creds.json"

--- a/tests/test_speech_settings_facade.py
+++ b/tests/test_speech_settings_facade.py
@@ -177,3 +177,15 @@ def test_save_openai_tab_uses_facade(speech_settings):
     speech_settings.save_openai_tab()
 
     atlas.update_openai_speech_settings.assert_called_once()
+
+
+def test_save_google_tab_uses_facade(speech_settings):
+    atlas = SimpleNamespace(update_google_speech_settings=Mock())
+
+    speech_settings.ATLAS = atlas
+    speech_settings.google_credentials_entry = _FakeEntry(" /tmp/google.json ")
+    speech_settings.tab_dirty[2] = True
+
+    speech_settings.save_google_tab()
+
+    atlas.update_google_speech_settings.assert_called_once_with("/tmp/google.json")


### PR DESCRIPTION
## Summary
- add a getter on the speech manager to return the persisted Google credentials path and surface it through the ATLAS facade
- update the speech settings UI to pull the saved path via the facade while logging lookup failures defensively
- extend unit coverage to exercise the new getter and ensure the Google save handler continues to call the ATLAS facade

## Testing
- pytest tests/test_speech_manager.py tests/test_speech_settings_facade.py

------
https://chatgpt.com/codex/tasks/task_e_68d18e8a77d08322818ab29499385648