### PR TITLE
Allow AnthropicGenerator to create its own ConfigManager

### DIFF
--- a/modules/Providers/Anthropic/Anthropic_gen_response.py
+++ b/modules/Providers/Anthropic/Anthropic_gen_response.py
@@ -9,8 +9,8 @@ from anthropic import AsyncAnthropic, APIError, RateLimitError
 import json
 
 class AnthropicGenerator:
-    def __init__(self, config_manager=ConfigManager):
-        self.config_manager = config_manager
+    def __init__(self, config_manager: Optional[ConfigManager] = None):
+        self.config_manager = config_manager or ConfigManager()
         self.logger = setup_logger(__name__)
         self.api_key = self.config_manager.get_anthropic_api_key()
         if not self.api_key:
@@ -219,7 +219,7 @@ class AnthropicGenerator:
         self.retry_delay = retry_delay
         self.logger.info(f"Retry delay set to: {retry_delay} seconds")
 
-def setup_anthropic_generator(config_manager: ConfigManager):
+def setup_anthropic_generator(config_manager: Optional[ConfigManager] = None):
     return AnthropicGenerator(config_manager)
 
 async def generate_response(
@@ -237,7 +237,7 @@ async def generate_response(
     return await generator.generate_response(messages, model, max_tokens, temperature, stream, current_persona, functions, **kwargs)
 
 async def process_response(response: Union[str, AsyncIterator[Union[str, Dict[str, Any]]]]) -> str:
-    generator = AnthropicGenerator(ConfigManager())
+    generator = setup_anthropic_generator()
     return await generator.process_response(response)
 
 def generate_response_sync(

--- a/tests/test_atlas_provider_wrappers.py
+++ b/tests/test_atlas_provider_wrappers.py
@@ -344,6 +344,24 @@ def test_anthropic_generate_response_sync_running_loop_error(monkeypatch):
     assert "use the async Anthropic API instead" in str(error)
 
 
+def test_anthropic_generator_uses_default_config(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
+    monkeypatch.setenv("DEFAULT_PROVIDER", "OpenAI")
+
+    from modules.Providers.Anthropic import Anthropic_gen_response as anthropic_module
+
+    class _StubClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    monkeypatch.setattr(anthropic_module, "AsyncAnthropic", _StubClient)
+
+    generator = anthropic_module.AnthropicGenerator()
+
+    assert generator.api_key == "anthropic-key"
+
+
 def _build_atlas(atlas_class):
     atlas = atlas_class.__new__(atlas_class)
     atlas.provider_manager = None


### PR DESCRIPTION
## Summary
- allow `AnthropicGenerator` to fall back to a local `ConfigManager` when no instance is provided
- update helper functions to rely on the optional configuration manager path
- add regression coverage to ensure the default generator reads the Anthropic API key from configuration

## Testing
- pytest tests/test_atlas_provider_wrappers.py::test_anthropic_generator_uses_default_config

------
https://chatgpt.com/codex/tasks/task_e_68d9c9aec8008322826601ff28d59a9b