### PR TITLE
Enhance Anthropic provider configuration options

### DIFF
--- a/ATLAS/provider_manager.py
+++ b/ATLAS/provider_manager.py
@@ -288,6 +288,11 @@ class ProviderManager:
         max_retries: Optional[int] = None,
         retry_delay: Optional[int] = None,
         stop_sequences: Any = ConfigManager.UNSET,
+        tool_choice: Any = ConfigManager.UNSET,
+        tool_choice_name: Any = ConfigManager.UNSET,
+        metadata: Any = ConfigManager.UNSET,
+        thinking: Optional[bool] = None,
+        thinking_budget: Any = ConfigManager.UNSET,
     ) -> Dict[str, Any]:
         """Persist Anthropic defaults and refresh the active generator when possible."""
 
@@ -304,6 +309,11 @@ class ProviderManager:
                 max_retries=max_retries,
                 retry_delay=retry_delay,
                 stop_sequences=stop_sequences,
+                tool_choice=tool_choice,
+                tool_choice_name=tool_choice_name,
+                metadata=metadata,
+                thinking=thinking,
+                thinking_budget=thinking_budget,
             )
         except Exception as exc:
             self.logger.error("Failed to persist Anthropic settings: %s", exc, exc_info=True)
@@ -331,6 +341,15 @@ class ProviderManager:
                 generator.set_max_retries(settings.get("max_retries", 3))
                 generator.set_retry_delay(settings.get("retry_delay", 5))
                 generator.set_stop_sequences(settings.get("stop_sequences", []))
+                generator.set_tool_choice(
+                    settings.get("tool_choice"),
+                    settings.get("tool_choice_name"),
+                )
+                generator.set_metadata(settings.get("metadata"))
+                generator.set_thinking(
+                    settings.get("thinking"),
+                    settings.get("thinking_budget"),
+                )
             except Exception as exc:  # pragma: no cover - defensive logging
                 self.logger.warning(
                     "Unable to apply Anthropic settings to the live generator: %s",

--- a/GTKUI/Provider_manager/Settings/Anthropic_settings.py
+++ b/GTKUI/Provider_manager/Settings/Anthropic_settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """GTK window for configuring Anthropic provider defaults."""
 
+import json
 import logging
 from typing import Dict, List, Optional, Tuple
 
@@ -51,6 +52,11 @@ class AnthropicSettingsWindow(Gtk.Window):
             "max_retries": 3,
             "retry_delay": 5,
             "stop_sequences": [],
+            "tool_choice": "auto",
+            "tool_choice_name": None,
+            "metadata": {},
+            "thinking": False,
+            "thinking_budget": None,
         }
         self._initial_settings: Dict[str, object] = {}
 
@@ -104,7 +110,42 @@ class AnthropicSettingsWindow(Gtk.Window):
         self.function_call_toggle.set_halign(Gtk.Align.START)
         if hasattr(self.function_call_toggle, "connect"):
             self.function_call_toggle.connect("toggled", self._update_save_button_state)
+            self.function_call_toggle.connect("toggled", self._update_tool_choice_state)
         grid.attach(self.function_call_toggle, 0, row, 2, 1)
+
+        row += 1
+        tool_choice_label = Gtk.Label(label="Tool behaviour:")
+        tool_choice_label.set_xalign(0.0)
+        grid.attach(tool_choice_label, 0, row, 1, 1)
+
+        self.tool_choice_combo = Gtk.ComboBoxText()
+        self.tool_choice_combo.set_hexpand(True)
+        self._tool_choice_map = [
+            ("auto", "Automatic (Anthropic decides)"),
+            ("any", "Require any tool call"),
+            ("none", "Never call tools"),
+            ("tool", "Request specific tool"),
+        ]
+        self._cached_tool_choice_value = "auto"
+        for key, label in self._tool_choice_map:
+            self.tool_choice_combo.append_text(label)
+        if hasattr(self.tool_choice_combo, "connect"):
+            self.tool_choice_combo.connect("changed", self._update_tool_choice_state)
+            self.tool_choice_combo.connect("changed", self._update_save_button_state)
+        grid.attach(self.tool_choice_combo, 1, row, 1, 1)
+
+        row += 1
+        preferred_tool_label = Gtk.Label(label="Preferred tool name:")
+        preferred_tool_label.set_xalign(0.0)
+        grid.attach(preferred_tool_label, 0, row, 1, 1)
+
+        self.tool_name_entry = Gtk.Entry()
+        self.tool_name_entry.set_hexpand(True)
+        self.tool_name_entry.set_placeholder_text("Optional tool name")
+        if hasattr(self.tool_name_entry, "connect"):
+            self.tool_name_entry.connect("changed", self._update_save_button_state)
+            self.tool_name_entry.connect("changed", self._update_tool_choice_state)
+        grid.attach(self.tool_name_entry, 1, row, 1, 1)
 
         row += 1
         temperature_label = Gtk.Label(label="Sampling temperature:")
@@ -192,6 +233,27 @@ class AnthropicSettingsWindow(Gtk.Window):
         grid.attach(stop_sequences_help, 0, row, 2, 1)
 
         row += 1
+        metadata_label = Gtk.Label(label="Request metadata:")
+        metadata_label.set_xalign(0.0)
+        grid.attach(metadata_label, 0, row, 1, 1)
+
+        self.metadata_entry = Gtk.Entry()
+        self.metadata_entry.set_hexpand(True)
+        self.metadata_entry.set_placeholder_text("key=value, team=research")
+        if hasattr(self.metadata_entry, "connect"):
+            self.metadata_entry.connect("changed", self._update_save_button_state)
+        grid.attach(self.metadata_entry, 1, row, 1, 1)
+
+        row += 1
+        metadata_help = Gtk.Label(
+            label="Comma separated pairs or JSON. Max 16 entries."
+        )
+        metadata_help.set_xalign(0.0)
+        if hasattr(metadata_help, "add_css_class"):
+            metadata_help.add_css_class("dim-label")
+        grid.attach(metadata_help, 0, row, 2, 1)
+
+        row += 1
         timeout_label = Gtk.Label(label="Request timeout (seconds):")
         timeout_label.set_xalign(0.0)
         grid.attach(timeout_label, 0, row, 1, 1)
@@ -223,6 +285,33 @@ class AnthropicSettingsWindow(Gtk.Window):
         if hasattr(self.retry_delay_spin, "connect"):
             self.retry_delay_spin.connect("value-changed", self._update_save_button_state)
         grid.attach(self.retry_delay_spin, 1, row, 1, 1)
+
+        row += 1
+        thinking_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        thinking_box.set_halign(Gtk.Align.START)
+        grid.attach(thinking_box, 0, row, 2, 1)
+
+        self.thinking_toggle = Gtk.CheckButton(label="Enable Claude thinking outputs (beta)")
+        if hasattr(self.thinking_toggle, "connect"):
+            self.thinking_toggle.connect("toggled", self._update_thinking_controls_state)
+            self.thinking_toggle.connect("toggled", self._update_save_button_state)
+        thinking_box.append(self.thinking_toggle)
+
+        self.thinking_budget_adjustment = Gtk.Adjustment(
+            lower=0,
+            upper=32768,
+            step_increment=128,
+            page_increment=512,
+            value=0,
+        )
+        self.thinking_budget_spin = Gtk.SpinButton(
+            adjustment=self.thinking_budget_adjustment,
+            digits=0,
+        )
+        self.thinking_budget_spin.set_tooltip_text("Optional budget tokens when thinking is enabled.")
+        if hasattr(self.thinking_budget_spin, "connect"):
+            self.thinking_budget_spin.connect("value-changed", self._update_save_button_state)
+        thinking_box.append(self.thinking_budget_spin)
 
         button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         if hasattr(button_box, "set_halign"):
@@ -323,6 +412,15 @@ class AnthropicSettingsWindow(Gtk.Window):
             stop_sequences_list = []
         self.stop_sequences_entry.set_text(", ".join(stop_sequences_list))
 
+        tool_choice = settings.get("tool_choice") if isinstance(settings, dict) else self._defaults["tool_choice"]
+        tool_choice_name = (
+            settings.get("tool_choice_name") if isinstance(settings, dict) else self._defaults["tool_choice_name"]
+        )
+        self._set_tool_choice_widgets(str(tool_choice or "auto"), tool_choice_name)
+
+        metadata = settings.get("metadata") if isinstance(settings, dict) else self._defaults["metadata"]
+        self.metadata_entry.set_text(self._format_metadata_for_entry(metadata))
+
         timeout = settings.get("timeout") if isinstance(settings, dict) else 60
         if isinstance(timeout, (int, float)) and timeout > 0:
             self.timeout_spin.set_value(int(timeout))
@@ -334,6 +432,16 @@ class AnthropicSettingsWindow(Gtk.Window):
         retry_delay = settings.get("retry_delay") if isinstance(settings, dict) else 5
         if isinstance(retry_delay, (int, float)) and retry_delay >= 0:
             self.retry_delay_spin.set_value(int(retry_delay))
+
+        thinking_enabled = settings.get("thinking") if isinstance(settings, dict) else self._defaults["thinking"]
+        self.thinking_toggle.set_active(bool(thinking_enabled))
+
+        thinking_budget = settings.get("thinking_budget") if isinstance(settings, dict) else self._defaults["thinking_budget"]
+        if isinstance(thinking_budget, (int, float)) and thinking_budget > 0:
+            self.thinking_budget_spin.set_value(int(thinking_budget))
+        else:
+            self.thinking_budget_spin.set_value(0)
+        self._update_thinking_controls_state()
 
         self._initial_settings = {
             "model": self.model_combo.get_active_text(),
@@ -355,6 +463,15 @@ class AnthropicSettingsWindow(Gtk.Window):
             "timeout": self.timeout_spin.get_value_as_int(),
             "max_retries": self.max_retries_spin.get_value_as_int(),
             "retry_delay": self.retry_delay_spin.get_value_as_int(),
+            "tool_choice": self._get_tool_choice_value(),
+            "tool_choice_name": self._get_tool_choice_name(),
+            "metadata": self._parse_metadata_entry(self.metadata_entry.get_text()),
+            "thinking": self.thinking_toggle.get_active(),
+            "thinking_budget": (
+                self.thinking_budget_spin.get_value_as_int()
+                if self.thinking_budget_spin.get_value_as_int() > 0
+                else None
+            ),
         }
 
         self._refresh_api_key_status()
@@ -571,6 +688,15 @@ class AnthropicSettingsWindow(Gtk.Window):
             "timeout": self.timeout_spin.get_value_as_int(),
             "max_retries": self.max_retries_spin.get_value_as_int(),
             "retry_delay": self.retry_delay_spin.get_value_as_int(),
+            "tool_choice": self._get_tool_choice_value(),
+            "tool_choice_name": self._get_tool_choice_name(),
+            "metadata": self._parse_metadata_entry(self.metadata_entry.get_text()),
+            "thinking": self.thinking_toggle.get_active(),
+            "thinking_budget": (
+                self.thinking_budget_spin.get_value_as_int()
+                if self.thinking_budget_spin.get_value_as_int() > 0
+                else None
+            ),
         }
 
     def _activate_model(self, model: str) -> None:
@@ -613,6 +739,15 @@ class AnthropicSettingsWindow(Gtk.Window):
         self.timeout_spin.set_value(int(defaults.get("timeout", 60)))
         self.max_retries_spin.set_value(int(defaults.get("max_retries", 3)))
         self.retry_delay_spin.set_value(int(defaults.get("retry_delay", 5)))
+        self._set_tool_choice_widgets(str(defaults.get("tool_choice", "auto")), defaults.get("tool_choice_name"))
+        self.metadata_entry.set_text(self._format_metadata_for_entry(defaults.get("metadata", {})))
+        self.thinking_toggle.set_active(bool(defaults.get("thinking", False)))
+        budget = defaults.get("thinking_budget")
+        if isinstance(budget, (int, float)) and budget > 0:
+            self.thinking_budget_spin.set_value(int(budget))
+        else:
+            self.thinking_budget_spin.set_value(0)
+        self._update_thinking_controls_state()
         self._update_save_button_state()
 
     def _parse_stop_sequences_entry(self) -> List[str]:
@@ -620,6 +755,55 @@ class AnthropicSettingsWindow(Gtk.Window):
         if not raw:
             return []
         return [segment.strip() for segment in raw.split(",") if segment.strip()]
+
+    def _parse_metadata_entry(self, raw: str) -> Dict[str, str]:
+        text = (raw or "").strip()
+        if not text:
+            return {}
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = None
+
+        metadata: Dict[str, str] = {}
+        if isinstance(parsed, dict):
+            for key, value in parsed.items():
+                if not str(key).strip():
+                    continue
+                metadata[str(key).strip()] = "" if value is None else str(value).strip()
+        elif isinstance(parsed, list):
+            for entry in parsed:
+                if isinstance(entry, dict):
+                    for key, value in entry.items():
+                        if not str(key).strip():
+                            continue
+                        metadata[str(key).strip()] = "" if value is None else str(value).strip()
+                elif isinstance(entry, (list, tuple)) and len(entry) == 2:
+                    key, value = entry
+                    if not str(key).strip():
+                        continue
+                    metadata[str(key).strip()] = "" if value is None else str(value).strip()
+        else:
+            segments = [segment.strip() for segment in text.replace("\n", ",").split(",")]
+            for segment in segments:
+                if not segment:
+                    continue
+                if "=" not in segment:
+                    continue
+                key, value = segment.split("=", 1)
+                key = key.strip()
+                if not key:
+                    continue
+                metadata[key] = value.strip()
+
+        if len(metadata) > 16:
+            metadata = dict(list(metadata.items())[:16])
+        return metadata
+
+    def _format_metadata_for_entry(self, metadata: object) -> str:
+        if not isinstance(metadata, dict) or not metadata:
+            return ""
+        return ", ".join(f"{key}={value}" for key, value in metadata.items())
 
     def _update_save_button_state(self, *_args) -> None:
         if not hasattr(self, "save_button"):
@@ -632,6 +816,77 @@ class AnthropicSettingsWindow(Gtk.Window):
             self.save_button.set_sensitive(enabled)
         else:  # pragma: no cover - testing stubs
             self.save_button.sensitive = enabled
+
+    def _get_tool_choice_value(self) -> str:
+        result = None
+        if hasattr(self.tool_choice_combo, "get_active"):
+            try:
+                index = self.tool_choice_combo.get_active()
+            except TypeError:
+                index = None
+            if isinstance(index, int) and 0 <= index < len(self._tool_choice_map):
+                result = self._tool_choice_map[index][0]
+
+        if result is None:
+            active_text = ""
+            if hasattr(self.tool_choice_combo, "get_active_text"):
+                active_text = self.tool_choice_combo.get_active_text() or ""
+            else:
+                active_text = getattr(self.tool_choice_combo, "active_text", "")
+
+            for key, label in self._tool_choice_map:
+                if label == active_text:
+                    result = key
+                    break
+
+        if result is None:
+            result = getattr(self, "_cached_tool_choice_value", "auto")
+
+        self._cached_tool_choice_value = result
+        return result
+
+    def _get_tool_choice_name(self) -> Optional[str]:
+        name = self.tool_name_entry.get_text() if hasattr(self.tool_name_entry, "get_text") else ""
+        cleaned = (name or "").strip()
+        return cleaned or None
+
+    def _set_tool_choice_widgets(self, choice: str, name: Optional[str]) -> None:
+        key = str(choice or "auto").lower()
+        try:
+            index = [entry[0] for entry in self._tool_choice_map].index(key)
+        except ValueError:
+            index = 0
+        if hasattr(self.tool_choice_combo, "set_active"):
+            self.tool_choice_combo.set_active(index)
+        elif hasattr(self.tool_choice_combo, "set_active_id"):
+            self.tool_choice_combo.set_active_id(str(index))
+        elif hasattr(self.tool_choice_combo, "set_active_text"):
+            self.tool_choice_combo.set_active_text(self._tool_choice_map[index][1])
+        else:
+            setattr(self.tool_choice_combo, "active_text", self._tool_choice_map[index][1])
+            setattr(self.tool_choice_combo, "active_index", index)
+        if isinstance(name, str):
+            self.tool_name_entry.set_text(name)
+        else:
+            self.tool_name_entry.set_text("")
+        self._cached_tool_choice_value = self._tool_choice_map[index][0]
+        self._update_tool_choice_state()
+
+    def _update_tool_choice_state(self, *_args) -> None:
+        value = self._get_tool_choice_value()
+        self._cached_tool_choice_value = value
+        enabled = self.function_call_toggle.get_active() and value == "tool"
+        if hasattr(self.tool_name_entry, "set_sensitive"):
+            self.tool_name_entry.set_sensitive(enabled)
+        if not enabled:
+            self.tool_name_entry.set_placeholder_text("Optional tool name")
+        else:
+            self.tool_name_entry.set_placeholder_text("Enter tool name")
+
+    def _update_thinking_controls_state(self, *_args) -> None:
+        enabled = self.thinking_toggle.get_active()
+        if hasattr(self.thinking_budget_spin, "set_sensitive"):
+            self.thinking_budget_spin.set_sensitive(enabled)
 
     def _show_message(self, title: str, message: str, message_type: Gtk.MessageType) -> None:
         self._last_message = (title, message, message_type)

--- a/tests/test_atlas_provider_wrappers.py
+++ b/tests/test_atlas_provider_wrappers.py
@@ -215,6 +215,18 @@ def atlas_class(monkeypatch):
                 def set_retry_delay(self, _value):
                     return None
 
+                def set_stop_sequences(self, _value):
+                    return None
+
+                def set_tool_choice(self, *_args, **_kwargs):
+                    return None
+
+                def set_metadata(self, *_args, **_kwargs):
+                    return None
+
+                def set_thinking(self, *_args, **_kwargs):
+                    return None
+
             module.AnthropicGenerator = _StubAnthropicGenerator
             module.setup_anthropic_generator = lambda _cfg=None: _StubAnthropicGenerator()
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -189,12 +189,22 @@ def test_set_anthropic_settings_updates_state(config_manager):
         timeout=120,
         max_retries=5,
         retry_delay=9,
-        stop_sequences=["END", "<|stop|>"]
+        stop_sequences=["END", "<|stop|>"],
+        tool_choice="tool",
+        tool_choice_name="calendar_lookup",
+        metadata={"team": "atlas", "priority": "high"},
+        thinking=True,
+        thinking_budget=2048,
     )
 
     assert result["model"] == "claude-3-sonnet-20240229"
     assert result["top_k"] == 42
     assert result["stop_sequences"] == ["END", "<|stop|>"]
+    assert result["tool_choice"] == "tool"
+    assert result["tool_choice_name"] == "calendar_lookup"
+    assert result["metadata"] == {"team": "atlas", "priority": "high"}
+    assert result["thinking"] is True
+    assert result["thinking_budget"] == 2048
     stored = config_manager.config["ANTHROPIC_LLM"]
     assert stored["stream"] is False
     assert stored["function_calling"] is True
@@ -206,6 +216,11 @@ def test_set_anthropic_settings_updates_state(config_manager):
     assert stored["max_retries"] == 5
     assert stored["retry_delay"] == 9
     assert stored["stop_sequences"] == ["END", "<|stop|>"]
+    assert stored["tool_choice"] == "tool"
+    assert stored["tool_choice_name"] == "calendar_lookup"
+    assert stored["metadata"] == {"team": "atlas", "priority": "high"}
+    assert stored["thinking"] is True
+    assert stored["thinking_budget"] == 2048
 
 
 def test_get_anthropic_settings_returns_defaults(config_manager):
@@ -222,6 +237,11 @@ def test_get_anthropic_settings_returns_defaults(config_manager):
     assert snapshot["max_retries"] == 3
     assert snapshot["retry_delay"] == 5
     assert snapshot["stop_sequences"] == []
+    assert snapshot["tool_choice"] == "auto"
+    assert snapshot["tool_choice_name"] is None
+    assert snapshot["metadata"] == {}
+    assert snapshot["thinking"] is False
+    assert snapshot["thinking_budget"] is None
 
 
 def test_set_openai_llm_settings_clears_optional_fields(config_manager):


### PR DESCRIPTION
## Summary
- expand Anthropic configuration support with tool choice, metadata, and thinking controls in both the config manager and runtime generator
- add matching GTK settings fields so users can manage the new parameters from the Anthropic settings window
- update provider manager plumbing and test suite expectations for the richer Anthropic feature set

## Testing
- pytest tests/test_config_manager.py::test_set_anthropic_settings_updates_state tests/test_config_manager.py::test_get_anthropic_settings_returns_defaults tests/test_provider_manager.py::test_anthropic_settings_window_dispatches_updates -q


------
https://chatgpt.com/codex/tasks/task_e_68db260d88a483228d77dfdf8e3bb371