### PR TITLE
Add Gemini tool support and streaming function call coverage

### DIFF
--- a/modules/Providers/Google/GG_gen_response.py
+++ b/modules/Providers/Google/GG_gen_response.py
@@ -1,11 +1,20 @@
 # modules/Providers/Google/GG_gen_response.py
 
+import asyncio
+import json
+from typing import AsyncIterator, Dict, Iterable, List, Optional, Union
+
 import google.generativeai as genai
+from google.generativeai import types as genai_types
 from tenacity import retry, stop_after_attempt, wait_exponential
-from typing import List, Dict, Union, AsyncIterator
+
+from ATLAS.ToolManager import (
+    load_function_map_from_current_persona,
+    load_functions_from_json,
+)
 from ATLAS.config import ConfigManager
 from modules.logging.logger import setup_logger
-import asyncio
+
 
 class GoogleGeminiGenerator:
     def __init__(self, config_manager: ConfigManager):
@@ -18,68 +27,319 @@ class GoogleGeminiGenerator:
         genai.configure(api_key=self.api_key)
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10))
-    async def generate_response(self, messages: List[Dict[str, str]], model: str = "gemini-1.5-pro-latest", max_tokens: int = 32000, temperature: float = 0.0, stream: bool = True, current_persona=None, functions=None) -> Union[str, AsyncIterator[str]]:
+    async def generate_response(
+        self,
+        messages: List[Dict[str, str]],
+        model: str = "gemini-1.5-pro-latest",
+        max_tokens: int = 32000,
+        temperature: float = 0.0,
+        stream: bool = True,
+        current_persona=None,
+        functions=None,
+    ) -> Union[str, AsyncIterator[Union[str, Dict[str, Dict[str, str]]]]]:
         try:
-            prompt = self.convert_messages_to_prompt(messages)
-            model = genai.GenerativeModel(model_name=model)
-            self.logger.info(f"Generating response with Google Gemini using model: {model}")
-            
-            response = await asyncio.to_thread(
-                model.generate_content,
-                prompt,
-                generation_config=genai.types.GenerationConfig(
+            contents = self._convert_messages_to_contents(messages)
+            tools = self._build_tools_payload(functions, current_persona)
+
+            model_instance = genai.GenerativeModel(model_name=model)
+            self.logger.info(
+                "Generating response with Google Gemini using model: %s", model
+            )
+
+            request_kwargs = {
+                "generation_config": genai.types.GenerationConfig(
                     max_output_tokens=max_tokens,
-                    temperature=temperature
+                    temperature=temperature,
                 ),
-                stream=stream
+                "stream": stream,
+            }
+            if tools:
+                request_kwargs["tools"] = tools
+
+            response = await asyncio.to_thread(
+                model_instance.generate_content,
+                contents,
+                **request_kwargs,
             )
 
             if stream:
                 return self.stream_response(response)
-            else:
-                return response.text
+
+            function_calls = self._extract_function_calls(response)
+            if function_calls:
+                return {"function_call": function_calls[0]}
+
+            return response.text
 
         except Exception as e:
             self.logger.error(f"Error in Google Gemini API call: {str(e)}")
             raise
 
-    def convert_messages_to_prompt(self, messages: List[Dict[str, str]]) -> str:
-        prompt = ""
+    def _convert_messages_to_contents(
+        self, messages: List[Dict[str, Union[str, Dict, List]]]
+    ) -> List[genai_types.ContentDict]:
+        contents: List[genai_types.ContentDict] = []
         for message in messages:
-            role = message['role']
-            content = message['content']
-            
-            if role == 'system':
-                prompt += f"System: {content}\n\n"
-            elif role == 'user':
-                prompt += f"Human: {content}\n\n"
-            elif role == 'assistant':
-                prompt += f"Assistant: {content}\n\n"
-        
-        prompt += "Human: Please respond to the above context.\n\nAssistant:"
-        return prompt
+            role = message.get("role")
+            if not role:
+                continue
 
-    async def stream_response(self, response) -> AsyncIterator[str]:
+            content_payload = message.get("content")
+            parts = list(self._normalize_parts(content_payload))
+
+            function_call = message.get("function_call")
+            if function_call:
+                normalized_call = self._normalize_function_call(function_call)
+                if normalized_call:
+                    parts.append({"function_call": normalized_call})
+
+            tool_calls = message.get("tool_calls")
+            if isinstance(tool_calls, Iterable):
+                for tool_call in tool_calls:
+                    normalized_tool_call = self._normalize_function_call(tool_call)
+                    if normalized_tool_call:
+                        parts.append({"function_call": normalized_tool_call})
+
+            content_dict: genai_types.ContentDict = {
+                "role": role,
+                "parts": parts or [""],
+            }
+
+            if "metadata" in message and isinstance(message["metadata"], dict):
+                content_dict["metadata"] = dict(message["metadata"])
+
+            for optional_key in ("name", "tool_call_id", "id"):
+                if optional_key in message:
+                    content_dict[optional_key] = message[optional_key]
+
+            contents.append(content_dict)
+
+        return contents
+
+    def _normalize_parts(self, content_payload) -> Iterable[genai_types.PartDict]:
+        if content_payload is None:
+            return []
+
+        if isinstance(content_payload, str):
+            return [{"text": content_payload}]
+
+        if isinstance(content_payload, dict):
+            return [self._normalize_part_dict(content_payload)]
+
+        if isinstance(content_payload, Iterable):
+            normalized_parts: List[genai_types.PartDict] = []
+            for item in content_payload:
+                if isinstance(item, str):
+                    normalized_parts.append({"text": item})
+                elif isinstance(item, dict):
+                    normalized_parts.append(self._normalize_part_dict(item))
+                else:
+                    normalized_parts.append({"text": str(item)})
+            return normalized_parts
+
+        return [{"text": str(content_payload)}]
+
+    def _normalize_part_dict(self, payload: Dict) -> genai_types.PartDict:
+        if not isinstance(payload, dict):
+            return {"text": str(payload)}
+
+        if payload.get("type") == "text" and "text" in payload:
+            return {"text": payload["text"]}
+
+        if "text" in payload:
+            return {"text": payload["text"]}
+
+        if "function_call" in payload:
+            normalized_call = self._normalize_function_call(payload["function_call"])
+            if normalized_call:
+                return {"function_call": normalized_call}
+
+        if payload.get("type") == "function_call":
+            normalized_call = self._normalize_function_call(payload)
+            if normalized_call:
+                return {"function_call": normalized_call}
+
+        return payload
+
+    def _build_tools_payload(self, functions, current_persona) -> Optional[List[genai_types.Tool]]:
+        declared_functions: List[genai_types.FunctionDeclaration] = []
+        seen_names = set()
+
+        provided_functions = functions
+        if provided_functions is None and current_persona:
+            provided_functions = load_functions_from_json(current_persona)
+
+        if isinstance(provided_functions, dict):
+            provided_functions = provided_functions.get("functions") or provided_functions.get(
+                "items"
+            )
+
+        if isinstance(provided_functions, Iterable):
+            for function_payload in provided_functions:
+                declaration = self._to_function_declaration(function_payload)
+                if declaration and declaration.name not in seen_names:
+                    declared_functions.append(declaration)
+                    seen_names.add(declaration.name)
+
+        function_map = (
+            load_function_map_from_current_persona(current_persona)
+            if current_persona
+            else None
+        )
+        if isinstance(function_map, dict):
+            for name in function_map.keys():
+                if name in seen_names:
+                    continue
+                declared_functions.append(
+                    genai_types.FunctionDeclaration(
+                        name=name,
+                        description=f"Function available in persona toolbox: {name}",
+                        parameters={"type": "object", "properties": {}},
+                    )
+                )
+                seen_names.add(name)
+
+        if not declared_functions:
+            return None
+
+        return [genai_types.Tool(function_declarations=declared_functions)]
+
+    def _to_function_declaration(self, payload) -> Optional[genai_types.FunctionDeclaration]:
+        if not isinstance(payload, dict):
+            return None
+
+        name = payload.get("name")
+        if not name:
+            return None
+
+        description = payload.get("description") or ""
+        parameters = payload.get("parameters")
+        if parameters is None:
+            parameters = {"type": "object", "properties": {}}
+
+        return genai_types.FunctionDeclaration(
+            name=name,
+            description=description,
+            parameters=parameters,
+        )
+
+    def _normalize_function_call(self, payload) -> Optional[Dict[str, str]]:
+        if payload is None:
+            return None
+
+        if isinstance(payload, dict):
+            name = payload.get("name") or payload.get("function", {}).get("name")
+            args = (
+                payload.get("arguments")
+                or payload.get("args")
+                or payload.get("function", {}).get("arguments")
+            )
+        else:
+            name = getattr(payload, "name", None)
+            args = getattr(payload, "arguments", None)
+            if args is None:
+                args = getattr(payload, "args", None)
+
+        if not name:
+            return None
+
+        if isinstance(args, str):
+            arguments_json = args
+        elif args is None:
+            arguments_json = "{}"
+        else:
+            try:
+                arguments_json = json.dumps(dict(args))
+            except Exception:
+                try:
+                    arguments_json = json.dumps(args)
+                except TypeError:
+                    arguments_json = str(args)
+
+        return {"name": name, "arguments": arguments_json}
+
+    def _extract_function_calls(self, response) -> List[Dict[str, str]]:
+        calls: List[Dict[str, str]] = []
+        for candidate in getattr(response, "candidates", []) or []:
+            content = getattr(candidate, "content", None)
+            parts = getattr(content, "parts", None) if content is not None else None
+            if parts:
+                for part in parts:
+                    normalized = None
+                    if isinstance(part, dict):
+                        normalized = self._normalize_function_call(part.get("function_call"))
+                    else:
+                        normalized = self._normalize_function_call(
+                            getattr(part, "function_call", None)
+                        )
+                    if normalized:
+                        calls.append(normalized)
+        return calls
+
+    async def stream_response(
+        self, response
+    ) -> AsyncIterator[Union[str, Dict[str, Dict[str, str]]]]:
         for chunk in response:
-            if chunk.text:
+            if getattr(chunk, "text", None):
                 yield chunk.text
-            await asyncio.sleep(0)  # Allow other coroutines to run
+
+            for candidate in getattr(chunk, "candidates", []) or []:
+                content = getattr(candidate, "content", None)
+                parts = getattr(content, "parts", None) if content is not None else None
+                if not parts:
+                    continue
+
+                for part in parts:
+                    text_value = None
+                    function_call = None
+
+                    if isinstance(part, dict):
+                        if "text" in part:
+                            text_value = part.get("text")
+                        function_call = part.get("function_call")
+                    else:
+                        text_value = getattr(part, "text", None)
+                        function_call = getattr(part, "function_call", None)
+
+                    if text_value:
+                        yield text_value
+
+                    normalized_call = self._normalize_function_call(function_call)
+                    if normalized_call:
+                        yield {"function_call": normalized_call}
+
+            await asyncio.sleep(0)
 
     async def process_response(self, response) -> str:
         if isinstance(response, AsyncIterator):
             full_response = ""
             async for chunk in response:
-                full_response += chunk
+                if isinstance(chunk, str):
+                    full_response += chunk
             return full_response
         else:
             return response
 
+
 def setup_google_gemini_generator(config_manager: ConfigManager):
     return GoogleGeminiGenerator(config_manager)
 
-async def generate_response(config_manager: ConfigManager, messages: List[Dict[str, str]], model: str = "gemini-1.5-pro-latest", max_tokens: int = 32000, temperature: float = 0.0, stream: bool = True, current_persona=None, functions=None):
+
+async def generate_response(
+    config_manager: ConfigManager,
+    messages: List[Dict[str, str]],
+    model: str = "gemini-1.5-pro-latest",
+    max_tokens: int = 32000,
+    temperature: float = 0.0,
+    stream: bool = True,
+    current_persona=None,
+    functions=None,
+):
     generator = setup_google_gemini_generator(config_manager)
-    return await generator.generate_response(messages, model, max_tokens, temperature, stream, current_persona, functions)
+    return await generator.generate_response(
+        messages, model, max_tokens, temperature, stream, current_persona, functions
+    )
+
 
 async def process_response(response: Union[str, AsyncIterator[str]]) -> str:
     if isinstance(response, str):
@@ -87,7 +347,9 @@ async def process_response(response: Union[str, AsyncIterator[str]]) -> str:
     elif isinstance(response, AsyncIterator):
         full_response = ""
         async for chunk in response:
-            full_response += chunk
+            if isinstance(chunk, str):
+                full_response += chunk
         return full_response
     else:
         raise ValueError(f"Unexpected response type: {type(response)}")
+

--- a/tests/test_google_generator.py
+++ b/tests/test_google_generator.py
@@ -1,0 +1,170 @@
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+class _DummyGenerationConfig:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _DummyFunctionDeclaration:
+    def __init__(self, *, name: str, description: str, parameters=None):
+        self.name = name
+        self.description = description
+        self.parameters = parameters or {}
+
+
+class _DummyTool:
+    def __init__(self, function_declarations):
+        self.function_declarations = list(function_declarations)
+
+
+genai_module = types.ModuleType("google.generativeai")
+genai_types_module = types.ModuleType("google.generativeai.types")
+genai_module.configure = lambda **_: None
+genai_module.types = genai_types_module
+genai_module.GenerativeModel = None
+genai_types_module.GenerationConfig = _DummyGenerationConfig
+genai_types_module.FunctionDeclaration = _DummyFunctionDeclaration
+genai_types_module.Tool = _DummyTool
+genai_types_module.ContentDict = dict
+genai_types_module.PartDict = dict
+
+sys.modules["google.generativeai"] = genai_module
+sys.modules["google.generativeai.types"] = genai_types_module
+
+if "tenacity" not in sys.modules:
+    tenacity_stub = types.ModuleType("tenacity")
+
+    def _retry_stub(*_args, **_kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    tenacity_stub.retry = _retry_stub
+    tenacity_stub.stop_after_attempt = lambda *_args, **_kwargs: None
+    tenacity_stub.wait_exponential = lambda *_args, **_kwargs: None
+    sys.modules["tenacity"] = tenacity_stub
+
+if "yaml" not in sys.modules:
+    yaml_stub = types.ModuleType("yaml")
+    yaml_stub.safe_load = lambda *_args, **_kwargs: {}
+    yaml_stub.dump = lambda *_args, **_kwargs: None
+    sys.modules["yaml"] = yaml_stub
+
+if "dotenv" not in sys.modules:
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *_args, **_kwargs: None
+    dotenv_stub.set_key = lambda *_args, **_kwargs: None
+    dotenv_stub.find_dotenv = lambda *_args, **_kwargs: ""
+    sys.modules["dotenv"] = dotenv_stub
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("GOOGLE_API_KEY", "test-key")
+
+import google.generativeai as genai
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "modules"
+    / "Providers"
+    / "Google"
+    / "GG_gen_response.py"
+)
+spec = importlib.util.spec_from_file_location("google_module", MODULE_PATH)
+google_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(google_module)
+
+
+class DummyConfig:
+    def get_google_api_key(self):
+        return "test-key"
+
+
+def test_google_generator_streams_function_call(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(genai, "configure", lambda **_: None)
+
+    class DummyResponse:
+        def __init__(self):
+            function_call_part = SimpleNamespace(
+                function_call=SimpleNamespace(name="tool_action", args={"value": 1})
+            )
+            text_chunk = SimpleNamespace(text="Hello", candidates=[])
+            function_chunk = SimpleNamespace(
+                text="",
+                candidates=[
+                    SimpleNamespace(
+                        content=SimpleNamespace(parts=[function_call_part])
+                    )
+                ],
+            )
+            self._chunks = [text_chunk, function_chunk]
+
+        def __iter__(self):
+            return iter(self._chunks)
+
+        @property
+        def candidates(self):
+            return []
+
+        @property
+        def text(self):
+            return "Hello"
+
+    class DummyModel:
+        def __init__(self, model_name):
+            captured["model_name"] = model_name
+
+        def generate_content(self, contents, **kwargs):
+            captured["contents"] = contents
+            captured["kwargs"] = kwargs
+            return DummyResponse()
+
+    monkeypatch.setattr(genai, "GenerativeModel", DummyModel)
+
+    generator = google_module.GoogleGeminiGenerator(DummyConfig())
+
+    async def exercise():
+        stream = await generator.generate_response(
+            messages=[{"role": "user", "content": "Hi"}],
+            model="gemini-unit-test",
+            stream=True,
+            functions=[
+                {
+                    "name": "tool_action",
+                    "description": "A sample tool",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"value": {"type": "integer"}},
+                        "required": ["value"],
+                    },
+                }
+            ],
+        )
+
+        chunks = []
+        async for item in stream:
+            chunks.append(item)
+        return chunks
+
+    chunks = asyncio.run(exercise())
+
+    assert chunks[0] == "Hello"
+    assert chunks[1] == {"function_call": {"name": "tool_action", "arguments": "{\"value\": 1}"}}
+
+    kwargs = captured["kwargs"]
+    tools = kwargs["tools"]
+    assert len(tools) == 1
+    declarations = list(tools[0].function_declarations)
+    assert declarations[0].name == "tool_action"
+    assert declarations[0].description == "A sample tool"
+


### PR DESCRIPTION
## Summary
- convert Google Gemini chat messages into Content objects and build tool declarations from provided functions and persona maps
- pass translated tools to generate_content, return function_call payloads, and surface streamed text and tool calls
- add a unit test that stubs the Gemini client and verifies streamed function call handling

## Testing
- pytest tests/test_google_generator.py


------
https://chatgpt.com/codex/tasks/task_e_68db2dd869588322b8e33d6b5d0e47f1