### PR TITLE
Add Google streaming configuration and UI toggle

### DIFF
--- a/ATLAS/provider_manager.py
+++ b/ATLAS/provider_manager.py
@@ -287,6 +287,7 @@ class ProviderManager:
         safety_settings: Optional[Any] = None,
         response_mime_type: Optional[str] = None,
         system_instruction: Optional[str] = None,
+        stream: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Persist Google Gemini defaults and promote the saved model when possible.
 
@@ -301,6 +302,7 @@ class ProviderManager:
             safety_settings: Optional safety configuration.
             response_mime_type: Optional MIME hint for the response.
             system_instruction: Optional default system instruction.
+            stream: Optional flag toggling streaming responses by default.
         """
 
         setter = getattr(self.config_manager, "set_google_llm_settings", None)
@@ -323,6 +325,7 @@ class ProviderManager:
                 safety_settings=safety_settings,
                 response_mime_type=response_mime_type,
                 system_instruction=system_instruction,
+                stream=stream,
             )
         except Exception as exc:
             self.logger.error("Failed to persist Google settings: %s", exc, exc_info=True)

--- a/GTKUI/Provider_manager/Settings/Google_settings.py
+++ b/GTKUI/Provider_manager/Settings/Google_settings.py
@@ -54,6 +54,7 @@ class GoogleSettingsWindow(Gtk.Window):
             "safety_settings": [],
             "response_mime_type": "",
             "system_instruction": "",
+            "stream": True,
         }
         self._safety_controls: Dict[str, Tuple[Gtk.CheckButton, Gtk.ComboBoxText]] = {}
         self._available_models: List[str] = []
@@ -184,6 +185,14 @@ class GoogleSettingsWindow(Gtk.Window):
             "Number of candidates to request per prompt. Higher values increase cost."
         )
         grid.attach(self.candidate_spin, 1, row, 1, 1)
+
+        row += 1
+        self.stream_toggle = Gtk.CheckButton(label="Enable streaming responses")
+        self.stream_toggle.set_halign(Gtk.Align.START)
+        self.stream_toggle.set_tooltip_text(
+            "Toggle to stream token updates during Gemini completions."
+        )
+        grid.attach(self.stream_toggle, 0, row, 2, 1)
 
         row += 1
         max_output_label = Gtk.Label(label="Max output tokens:")
@@ -368,6 +377,8 @@ class GoogleSettingsWindow(Gtk.Window):
         candidate_count = self._defaults.get("candidate_count", 1)
         if isinstance(candidate_count, (int, float)) and candidate_count > 0:
             self.candidate_spin.set_value(int(candidate_count))
+
+        self.stream_toggle.set_active(bool(self._defaults.get("stream", True)))
 
         max_output_tokens = self._defaults.get("max_output_tokens")
         if isinstance(max_output_tokens, (int, float)) and max_output_tokens > 0:
@@ -587,6 +598,7 @@ class GoogleSettingsWindow(Gtk.Window):
             "safety_settings": self._collect_safety_settings(),
             "response_mime_type": self._sanitize_response_mime_type(),
             "system_instruction": self._sanitize_system_instruction(),
+            "stream": self.stream_toggle.get_active(),
         }
 
         setter = getattr(self.ATLAS, "set_google_llm_settings", None)


### PR DESCRIPTION
## Summary
- persist the Google Gemini streaming preference in the config manager and provider manager
- allow the Google generator to accept an optional stream flag with a config fallback
- expose a streaming toggle in the Google settings window and extend tests for the new behaviour

## Testing
- pytest tests/test_google_generator.py
- pytest tests/test_provider_manager.py::test_google_settings_round_trips_custom_fields tests/test_provider_manager.py::test_set_google_llm_settings_updates_provider_state tests/test_provider_manager.py::test_generate_response_uses_google_defaults

------
https://chatgpt.com/codex/tasks/task_e_68dc358286a48322873f4e7f7a6ccffa