### PR TITLE
Enforce JSON MIME type when configuring Google schemas

### DIFF
--- a/ATLAS/config.py
+++ b/ATLAS/config.py
@@ -837,12 +837,27 @@ class ConfigManager:
         ) -> Dict[str, Any]:
             if value is None:
                 try:
-                    return self._coerce_response_schema(previous)
+                    schema = self._coerce_response_schema(previous)
                 except ValueError:
-                    return {}
-            if value in ({}, ""):
-                return {}
-            return self._coerce_response_schema(value)
+                    schema = {}
+            elif value in ({}, ""):
+                schema = {}
+            else:
+                schema = self._coerce_response_schema(value)
+
+            if schema:
+                mime_value = settings_block.get('response_mime_type') or ''
+                normalized_mime = str(mime_value).strip().lower()
+                if not normalized_mime:
+                    settings_block['response_mime_type'] = 'application/json'
+                elif normalized_mime != 'application/json':
+                    raise ValueError(
+                        "Response MIME type must be 'application/json' when a response schema is provided."
+                    )
+                else:
+                    settings_block['response_mime_type'] = 'application/json'
+
+            return schema
 
         settings_block['response_schema'] = _normalize_response_schema(
             response_schema,

--- a/GTKUI/Provider_manager/Settings/Google_settings.py
+++ b/GTKUI/Provider_manager/Settings/Google_settings.py
@@ -663,6 +663,22 @@ class GoogleSettingsWindow(Gtk.Window):
             self._show_message("Validation", str(exc), Gtk.MessageType.WARNING)
             return
 
+        schema = payload["response_schema"]
+        if schema not in (None, "", {}):
+            current_mime = payload.get("response_mime_type") or ""
+            normalized_mime = current_mime.strip().lower()
+            if normalized_mime and normalized_mime != "application/json":
+                self._show_message(
+                    "Validation",
+                    (
+                        "Response MIME type must be 'application/json' when a response "
+                        "schema is provided."
+                    ),
+                    Gtk.MessageType.WARNING,
+                )
+                return
+            payload["response_mime_type"] = "application/json"
+
         setter = getattr(self.ATLAS, "set_google_llm_settings", None)
         if not callable(setter):
             self._show_message(

--- a/modules/Providers/Google/GG_gen_response.py
+++ b/modules/Providers/Google/GG_gen_response.py
@@ -271,6 +271,12 @@ class GoogleGeminiGenerator:
 
             effective_response_schema = _normalise_schema(response_schema)
 
+            if (
+                effective_response_schema is not None
+                and not effective_response_mime_type
+            ):
+                effective_response_mime_type = "application/json"
+
             model_instance = genai.GenerativeModel(model_name=effective_model)
             self.logger.info(
                 "Generating response with Google Gemini using model: %s",

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -162,6 +162,27 @@ def test_set_google_llm_settings_updates_state(config_manager):
     assert config_manager.config["GOOGLE_LLM"]["max_output_tokens"] == 16000
 
 
+def test_set_google_llm_settings_autofills_json_mime_for_schema(config_manager):
+    snapshot = config_manager.set_google_llm_settings(
+        model="gemini-1.5-flash",
+        response_schema={"type": "object"},
+        response_mime_type="",
+    )
+
+    assert snapshot["response_mime_type"] == "application/json"
+    stored = config_manager.get_google_llm_settings()
+    assert stored["response_mime_type"] == "application/json"
+
+
+def test_set_google_llm_settings_rejects_non_json_mime_with_schema(config_manager):
+    with pytest.raises(ValueError):
+        config_manager.set_google_llm_settings(
+            model="gemini-1.5-flash",
+            response_schema={"type": "object"},
+            response_mime_type="text/plain",
+        )
+
+
 def test_get_google_llm_settings_returns_copy(config_manager):
     config_manager.set_google_llm_settings(
         model="gemini-1.5-pro",


### PR DESCRIPTION
## Summary
- ensure the Google settings UI enforces an application/json MIME type when saving a response schema
- validate Google LLM configuration and runtime defaults to keep schema usage aligned with application/json and cover with unit tests

## Testing
- pytest tests/test_config_manager.py tests/test_google_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68dc45d8ae348322914ba0e751da48c1