### PR TITLE
Add Gemini tool config persistence and tool_config plumbing

### DIFF
--- a/ATLAS/provider_manager.py
+++ b/ATLAS/provider_manager.py
@@ -289,6 +289,8 @@ class ProviderManager:
         system_instruction: Optional[str] = None,
         stream: Optional[bool] = None,
         function_calling: Optional[bool] = None,
+        function_call_mode: Optional[str] = None,
+        allowed_function_names: Optional[Any] = None,
         response_schema: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Persist Google Gemini defaults and promote the saved model when possible.
@@ -306,6 +308,8 @@ class ProviderManager:
             system_instruction: Optional default system instruction.
             stream: Optional flag toggling streaming responses by default.
             function_calling: Optional flag toggling Gemini tool calling by default.
+            function_call_mode: Optional Gemini tool calling mode preference.
+            allowed_function_names: Optional whitelist restricting Gemini tool access.
             response_schema: Optional JSON schema enforced for responses.
         """
 
@@ -331,6 +335,8 @@ class ProviderManager:
                 system_instruction=system_instruction,
                 stream=stream,
                 function_calling=function_calling,
+                function_call_mode=function_call_mode,
+                allowed_function_names=allowed_function_names,
                 response_schema=response_schema,
             )
         except Exception as exc:


### PR DESCRIPTION
## Summary
- persist Google Gemini function call mode and allowed function names in the config manager and provider plumbing
- extend the Google settings UI so users can manage the new tool-calling mode and whitelist
- update the Gemini generator to emit the proper tool_config payload and add tests covering the new behaviour

## Testing
- pytest tests/test_config_manager.py
- pytest tests/test_provider_manager.py tests/test_google_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4b40271c83229196edb10dd44660