### PR TITLE
Preserve Google allowlists when tool calling is disabled

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -847,6 +847,12 @@ class ATLAS:
         safety_settings: Optional[Any] = None,
         response_mime_type: Optional[str] = None,
         system_instruction: Optional[str] = None,
+        stream: Optional[bool] = None,
+        function_calling: Optional[bool] = None,
+        function_call_mode: Optional[str] = None,
+        allowed_function_names: Optional[Any] = None,
+        response_schema: Optional[Any] = None,
+        cached_allowed_function_names: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Persist Google defaults through the provider manager facade."""
 
@@ -866,6 +872,12 @@ class ATLAS:
             safety_settings=safety_settings,
             response_mime_type=response_mime_type,
             system_instruction=system_instruction,
+            stream=stream,
+            function_calling=function_calling,
+            function_call_mode=function_call_mode,
+            allowed_function_names=allowed_function_names,
+            response_schema=response_schema,
+            cached_allowed_function_names=cached_allowed_function_names,
         )
 
     def set_anthropic_settings(

--- a/ATLAS/provider_manager.py
+++ b/ATLAS/provider_manager.py
@@ -292,6 +292,7 @@ class ProviderManager:
         function_call_mode: Optional[str] = None,
         allowed_function_names: Optional[Any] = None,
         response_schema: Optional[Any] = None,
+        cached_allowed_function_names: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Persist Google Gemini defaults and promote the saved model when possible.
 
@@ -338,6 +339,7 @@ class ProviderManager:
                 function_call_mode=function_call_mode,
                 allowed_function_names=allowed_function_names,
                 response_schema=response_schema,
+                cached_allowed_function_names=cached_allowed_function_names,
             )
         except Exception as exc:
             self.logger.error("Failed to persist Google settings: %s", exc, exc_info=True)

--- a/modules/Providers/Anthropic/Anthropic_gen_response.py
+++ b/modules/Providers/Anthropic/Anthropic_gen_response.py
@@ -125,7 +125,7 @@ def _normalise_stop_sequences(value: Any) -> List[str]:
 def _normalise_metadata(value: Any) -> Dict[str, str]:
     """Normalise metadata inputs to Anthropic's expected mapping structure."""
 
-    if value in {None, "", {}}:
+    if value in (None, "", {}):
         return {}
 
     metadata: Dict[str, str] = {}

--- a/modules/Providers/Google/GG_gen_response.py
+++ b/modules/Providers/Google/GG_gen_response.py
@@ -335,7 +335,7 @@ class GoogleGeminiGenerator:
             )
 
             request_kwargs = {
-                "generation_config": genai.types.GenerationConfig(
+                "generation_config": genai_types.GenerationConfig(
                     **{
                         key: value
                         for key, value in {


### PR DESCRIPTION
## Summary
- cache Google Gemini allowed function names when tool calling is disabled and restore them when it is re-enabled
- update the GTK settings dialog and PR helpers to keep cached allowlists while omitting them from live provider updates
- harden GUI helpers and tests for stub GTK environments and add coverage for the new caching behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc5567660483229e15ba7b9c3b20f4