### PR TITLE
Add Gemini seed and logprob configuration controls

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -853,6 +853,8 @@ class ATLAS:
         allowed_function_names: Optional[Any] = None,
         response_schema: Optional[Any] = None,
         cached_allowed_function_names: Optional[Any] = None,
+        seed: Optional[Any] = None,
+        response_logprobs: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Persist Google defaults through the provider manager facade."""
 
@@ -878,6 +880,8 @@ class ATLAS:
             allowed_function_names=allowed_function_names,
             response_schema=response_schema,
             cached_allowed_function_names=cached_allowed_function_names,
+            seed=seed,
+            response_logprobs=response_logprobs,
         )
 
     def set_anthropic_settings(

--- a/tests/test_google_generator.py
+++ b/tests/test_google_generator.py
@@ -474,6 +474,8 @@ def test_google_generator_applies_persisted_settings(monkeypatch):
             "type": "object",
             "properties": {"message": {"type": "string"}},
         },
+        "seed": 77,
+        "response_logprobs": True,
     }
     config = DummyConfig(settings=settings)
     generator = google_module.GoogleGeminiGenerator(config)
@@ -493,6 +495,8 @@ def test_google_generator_applies_persisted_settings(monkeypatch):
     assert generation_config.kwargs["top_k"] == 32
     assert generation_config.kwargs["candidate_count"] == 3
     assert generation_config.kwargs["stop_sequences"] == ["###"]
+    assert generation_config.kwargs["seed"] == 77
+    assert generation_config.kwargs["response_logprobs"] is True
     assert captured["kwargs"]["safety_settings"] == settings["safety_settings"]
     assert captured["kwargs"]["response_mime_type"] == "application/json"
     assert captured["kwargs"]["system_instruction"] == "Respond in JSON."
@@ -637,6 +641,8 @@ def test_google_generator_prefers_call_overrides(monkeypatch):
             "type": "object",
             "properties": {"config": {"type": "string"}},
         },
+        "seed": 555,
+        "response_logprobs": True,
     }
     config = DummyConfig(settings=base_settings)
     generator = google_module.GoogleGeminiGenerator(config)
@@ -662,6 +668,8 @@ def test_google_generator_prefers_call_overrides(monkeypatch):
                 "type": "object",
                 "properties": {"call": {"type": "number"}},
             },
+            seed=202,
+            response_logprobs=False,
         )
         if hasattr(response, "__anext__"):
             chunks = []
@@ -680,6 +688,8 @@ def test_google_generator_prefers_call_overrides(monkeypatch):
     assert generation_config.kwargs["top_k"] == 8
     assert generation_config.kwargs["candidate_count"] == 2
     assert generation_config.kwargs["stop_sequences"] == ["CALL"]
+    assert generation_config.kwargs["seed"] == 202
+    assert "response_logprobs" not in generation_config.kwargs
     assert captured["kwargs"]["safety_settings"] == override_safety
     assert captured["kwargs"]["response_mime_type"] == "text/plain"
     assert captured["kwargs"]["system_instruction"] == "Follow call input."
@@ -689,6 +699,8 @@ def test_google_generator_prefers_call_overrides(monkeypatch):
         "properties": {"call": {"type": "number"}},
     }
     assert config._settings["stop_sequences"] == ["CONFIG"]
+    assert config._settings["seed"] == 555
+    assert config._settings["response_logprobs"] is True
 
 
 def test_google_generator_rejects_invalid_schema(monkeypatch):

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -857,6 +857,8 @@ class DummyConfig:
         allowed_function_names=None,
         response_schema=None,
         cached_allowed_function_names=None,
+        seed=None,
+        response_logprobs=None,
     ):
         if model:
             self._google_settings["model"] = model
@@ -891,6 +893,10 @@ class DummyConfig:
                 self._google_settings["max_output_tokens"] = None
         elif max_output_tokens is not None:
             self._google_settings["max_output_tokens"] = int(max_output_tokens)
+        if seed in ("", None):
+            self._google_settings["seed"] = None
+        elif seed is not None:
+            self._google_settings["seed"] = int(seed)
         if stream is not None:
             self._google_settings["stream"] = bool(stream)
         if function_calling is not None:
@@ -948,6 +954,8 @@ class DummyConfig:
                 raise ValueError(
                     "Response schema must be provided as a mapping or JSON string."
                 )
+        if response_logprobs is not None:
+            self._google_settings["response_logprobs"] = bool(response_logprobs)
 
         return dict(self._google_settings)
 
@@ -1779,6 +1787,8 @@ def test_set_google_llm_settings_updates_provider_state(provider_manager):
             "type": "object",
             "properties": {"result": {"type": "string"}},
         },
+        seed=2024,
+        response_logprobs=True,
     )
 
     assert result["success"] is True
@@ -1788,6 +1798,8 @@ def test_set_google_llm_settings_updates_provider_state(provider_manager):
         "type": "object",
         "properties": {"result": {"type": "string"}},
     }
+    assert result["data"]["seed"] == 2024
+    assert result["data"]["response_logprobs"] is True
     settings = provider_manager.config_manager.get_google_llm_settings()
     assert settings["model"] == "gemini-1.5-flash-latest"
     assert math.isclose(settings["temperature"], 0.55)
@@ -1806,6 +1818,8 @@ def test_set_google_llm_settings_updates_provider_state(provider_manager):
         "type": "object",
         "properties": {"result": {"type": "string"}},
     }
+    assert settings["seed"] == 2024
+    assert settings["response_logprobs"] is True
     assert provider_manager.model_manager.models["Google"][0] == "gemini-1.5-flash-latest"
     assert provider_manager.current_model == "gemini-1.5-flash-latest"
 


### PR DESCRIPTION
## Summary
- allow the Google config resolver and manager to persist optional seed and response_logprobs settings
- wire the new settings through ProviderManager and the Gemini generator so they reach the GenerationConfig payload
- expose seed and logprob controls in the GTK settings dialog and expand unit coverage for persistence and request construction

## Testing
- `pytest tests/test_config_manager.py tests/test_google_generator.py tests/test_provider_manager.py -k google`


------
https://chatgpt.com/codex/tasks/task_e_68dc698a85c8832283419817dc573fea