### PR TITLE
Apply global dark theme styling to provider dialogs

### DIFF
--- a/GTKUI/Provider_manager/Settings/Anthropic_settings.py
+++ b/GTKUI/Provider_manager/Settings/Anthropic_settings.py
@@ -11,7 +11,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib
 
-from GTKUI.Utils.utils import create_box
+from GTKUI.Utils.utils import apply_css, create_box
 from modules.background_tasks import run_async_in_thread
 
 logger = logging.getLogger(__name__)
@@ -22,6 +22,10 @@ class AnthropicSettingsWindow(Gtk.Window):
 
     def __init__(self, ATLAS, config_manager, parent_window):
         super().__init__(title="Anthropic Settings")
+        apply_css()
+        style_context = self.get_style_context()
+        style_context.add_class("chat-page")
+        style_context.add_class("sidebar")
         self.ATLAS = ATLAS
         self.config_manager = config_manager
         self.parent_window = parent_window

--- a/GTKUI/Provider_manager/Settings/Google_settings.py
+++ b/GTKUI/Provider_manager/Settings/Google_settings.py
@@ -11,7 +11,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib
 
-from GTKUI.Utils.utils import create_box
+from GTKUI.Utils.utils import apply_css, create_box
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,10 @@ class GoogleSettingsWindow(Gtk.Window):
 
     def __init__(self, ATLAS, config_manager, parent_window):
         super().__init__(title="Google Settings")
+        apply_css()
+        style_context = self.get_style_context()
+        style_context.add_class("chat-page")
+        style_context.add_class("sidebar")
         self.ATLAS = ATLAS
         self.config_manager = config_manager
         self.parent_window = parent_window

--- a/GTKUI/Provider_manager/Settings/HF_settings.py
+++ b/GTKUI/Provider_manager/Settings/HF_settings.py
@@ -19,7 +19,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, Gdk, GLib
 
-from GTKUI.Utils.utils import create_box
+from GTKUI.Utils.utils import apply_css, create_box
 
 
 logger = logging.getLogger(__name__)
@@ -36,12 +36,13 @@ class HuggingFaceSettingsWindow(Gtk.Window):
             parent_window: The parent GTK window.
         """
         super().__init__(title="HuggingFace Settings")
+        apply_css()
+        style_context = self.get_style_context()
+        style_context.add_class("chat-page")
+        style_context.add_class("sidebar")
         self.parent_window = parent_window
         self.set_transient_for(parent_window)
         self.set_modal(True)
-        
-        # Apply the CSS styling for this window.
-        self.apply_css_styling()
         
         self.set_default_size(800, 600)
         self.ATLAS = ATLAS
@@ -299,92 +300,6 @@ class HuggingFaceSettingsWindow(Gtk.Window):
             img = Gtk.Image.new_from_icon_name(fallback_icon_name)
             img.set_pixel_size(size)
             return img
-
-    def apply_css_styling(self):
-        """
-        Applies CSS styling to the HuggingFace settings window.
-        """
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data(b"""
-            * { 
-                background-color: #2b2b2b; 
-                color: white; 
-            }
-
-            entry, textview {
-                background-color: #1c1c1c;
-                color: white;
-                border: none;
-                border-radius: 5px;
-                font-size: 14px;
-                padding: 5px;
-                margin: 0;
-            }
-
-            entry {
-                min-height: 30px;
-            }
-
-            entry:focus {
-                outline: none;
-            }
-
-            textview {
-                caret-color: white;
-            }
-
-            textview text {
-                background-color: #1c1c1c;
-                color: white;
-                caret-color: white;
-            }
-
-            textview text selection {
-                background-color: #4a90d9;
-                color: white;
-            }
-
-            button {
-                background-color: #2b2b2b;
-                color: white;
-                padding: 8px;
-                border-radius: 3px;
-                border: 1px solid #4a4a4a;
-                font-size: 14px;
-            }
-
-            button:hover {
-                background-color: #4a90d9;
-                border: 1px solid #4a90d9;
-            }
-
-            button:active {
-                background-color: #357ABD;
-                border: 1px solid #357ABD;
-            }
-
-            label { 
-                margin: 5px;
-                color: #ffffff; 
-            }
-
-            notebook tab { 
-                background-color: #2b2b2b; 
-                color: white; 
-                padding: 8px; 
-            }
-
-            scrolledwindow {
-                border: none;
-                background-color: transparent;
-            }
-        """)
-        display = Gtk.Window().get_display()
-        Gtk.StyleContext.add_provider_for_display(
-            display,
-            css_provider,
-            Gtk.STYLE_PROVIDER_PRIORITY_USER
-        )
 
     # ---------------------------------------------------------------------
     # UI Builders

--- a/GTKUI/Provider_manager/Settings/OA_settings.py
+++ b/GTKUI/Provider_manager/Settings/OA_settings.py
@@ -12,7 +12,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib
 
-from GTKUI.Utils.utils import create_box
+from GTKUI.Utils.utils import apply_css, create_box
 from modules.background_tasks import run_async_in_thread
 
 logger = logging.getLogger(__name__)
@@ -23,6 +23,10 @@ class OpenAISettingsWindow(Gtk.Window):
 
     def __init__(self, ATLAS, config_manager, parent_window):
         super().__init__(title="OpenAI Settings")
+        apply_css()
+        style_context = self.get_style_context()
+        style_context.add_class("chat-page")
+        style_context.add_class("sidebar")
         self.ATLAS = ATLAS
         self.config_manager = config_manager
         self.parent_window = parent_window

--- a/GTKUI/Provider_manager/provider_management.py
+++ b/GTKUI/Provider_manager/provider_management.py
@@ -8,7 +8,7 @@ from gi.repository import Gtk, Gdk, GLib
 import os
 import logging
 
-from GTKUI.Utils.utils import create_box
+from GTKUI.Utils.utils import apply_css, create_box
 from .Settings.HF_settings import HuggingFaceSettingsWindow
 from .Settings.OA_settings import OpenAISettingsWindow
 from .Settings.Anthropic_settings import AnthropicSettingsWindow
@@ -72,6 +72,11 @@ class ProviderManagement:
         self.provider_window.set_transient_for(self.parent_window)
         self.provider_window.set_modal(True)
         self.provider_window.set_tooltip_text("Choose a default LLM provider or open its settings.")
+
+        apply_css()
+        style_context = self.provider_window.get_style_context()
+        style_context.add_class("chat-page")
+        style_context.add_class("sidebar")
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -237,7 +242,10 @@ class ProviderManagement:
         settings_window.set_modal(True)
         settings_window.set_tooltip_text(f"Update API key and settings for {provider_name}.")
 
-        self.apply_css_styling()
+        apply_css()
+        style_context = settings_window.get_style_context()
+        style_context.add_class("chat-page")
+        style_context.add_class("sidebar")
 
         main_vbox = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=10, margin=10)
         settings_window.set_child(main_vbox)
@@ -616,34 +624,3 @@ class ProviderManagement:
         dialog.set_tooltip_text("Close to continue.")
         dialog.present()
 
-    def apply_css_styling(self):
-        """
-        Applies CSS styling to the provider settings window.
-        This ensures a consistent look and feel across the application.
-        """
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data(b"""
-            * { background-color: #2b2b2b; color: white; }
-            label { margin: 5px; }
-            entry { background-color: #3c3c3c; color: white; }
-            button { background-color: #555555; color: white; }
-            button:hover { background-color: #4a90d9; }
-            button:active { background-color: #357ABD; }
-            .provider-label {
-                font-weight: bold;
-            }
-        """)
-        # Use the app's display if possible; fall back safely.
-        display = None
-        try:
-            if self.parent_window:
-                display = self.parent_window.get_display()
-        except Exception:
-            display = None
-        if display is None:
-            display = Gtk.Window().get_display()
-        Gtk.StyleContext.add_provider_for_display(
-            display,
-            css_provider,
-            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-        )


### PR DESCRIPTION
## Summary
- load the shared GTK CSS for the provider selector and attach the dark theme classes used by other windows
- update the provider settings windows to apply the global stylesheet and drop duplicated inline styling

## Testing
- not run (GTK UI requires a graphical session)


------
https://chatgpt.com/codex/tasks/task_e_68dc86eab8288322a3a90f6b997b9777