### PR TITLE
Scope dialog theming to dark surfaces

### DIFF
--- a/GTKUI/Persona_manager/General_Tab/general_tab.py
+++ b/GTKUI/Persona_manager/General_Tab/general_tab.py
@@ -6,6 +6,8 @@ import gi
 gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk, Gdk, Pango
 
+from GTKUI.Utils.utils import apply_css
+
 
 class InfoPopup(Gtk.Window):
     def __init__(self, parent, text):
@@ -13,6 +15,17 @@ class InfoPopup(Gtk.Window):
         self.set_transient_for(parent)
         self.set_modal(True)
         self.set_decorated(False)
+
+        try:
+            apply_css()
+        except (AttributeError, FileNotFoundError, RuntimeError):
+            pass
+        get_style_context = getattr(self, "get_style_context", None)
+        if callable(get_style_context):
+            style_context = get_style_context()
+            if hasattr(style_context, "add_class"):
+                style_context.add_class("chat-page")
+                style_context.add_class("sidebar")
 
         # Create a label with no wrapping
         label = Gtk.Label(label=text)

--- a/GTKUI/Provider_manager/provider_management.py
+++ b/GTKUI/Provider_manager/provider_management.py
@@ -594,6 +594,7 @@ class ProviderManagement:
             buttons=Gtk.ButtonsType.OK,
             text="Error",
         )
+        self._style_dialog(dialog)
         if hasattr(dialog, "set_secondary_text"):
             dialog.set_secondary_text(message)
         else:  # Fallback for API variations
@@ -616,6 +617,7 @@ class ProviderManagement:
             buttons=Gtk.ButtonsType.OK,
             text="Information",
         )
+        self._style_dialog(dialog)
         if hasattr(dialog, "set_secondary_text"):
             dialog.set_secondary_text(message)
         else:  # Fallback for API variations
@@ -623,4 +625,18 @@ class ProviderManagement:
         dialog.connect("response", lambda dialog, response: dialog.destroy())
         dialog.set_tooltip_text("Close to continue.")
         dialog.present()
+
+    def _style_dialog(self, dialog: Gtk.Widget) -> None:
+        """Ensure dialogs adopt the same dark theme styling as the parent UI."""
+
+        try:
+            apply_css()
+        except (AttributeError, FileNotFoundError, RuntimeError) as exc:
+            self.logger.debug("Skipping CSS application for dialog: %s", exc)
+        get_style_context = getattr(dialog, "get_style_context", None)
+        if callable(get_style_context):
+            style_context = get_style_context()
+            if hasattr(style_context, "add_class"):
+                style_context.add_class("chat-page")
+                style_context.add_class("sidebar")
 

--- a/GTKUI/Settings/Speech/speech_settings.py
+++ b/GTKUI/Settings/Speech/speech_settings.py
@@ -183,9 +183,24 @@ class SpeechSettings(Gtk.Window):
             buttons=Gtk.ButtonsType.OK,
             text=title,
         )
+        self._style_dialog(dialog)
         dialog.format_secondary_text(message)
         dialog.run()
         dialog.destroy()
+
+    def _style_dialog(self, dialog: Gtk.Widget) -> None:
+        """Apply the shared dark theme styling to transient dialogs."""
+
+        try:
+            apply_css()
+        except (AttributeError, FileNotFoundError, RuntimeError) as exc:
+            logger.debug("Skipping CSS application for dialog: %s", exc)
+        get_style_context = getattr(dialog, "get_style_context", None)
+        if callable(get_style_context):
+            style_context = get_style_context()
+            if hasattr(style_context, "add_class"):
+                style_context.add_class("chat-page")
+                style_context.add_class("sidebar")
 
     def _build_secret_row(self, label_text: str, default_visible: bool = False):
         """
@@ -250,6 +265,7 @@ class SpeechSettings(Gtk.Window):
                 buttons=Gtk.ButtonsType.NONE,
                 text="You have unsaved changes in this tab."
             )
+            self._style_dialog(dialog)
             dialog.format_secondary_text("Do you want to save your changes before switching tabs?")
             dialog.add_button("Save", Gtk.ResponseType.OK)
             dialog.add_button("Discard", Gtk.ResponseType.CANCEL)
@@ -1096,6 +1112,7 @@ class SpeechSettings(Gtk.Window):
             buttons=Gtk.ButtonsType.OK,
             text="Transcription History"
         )
+        self._style_dialog(dialog)
         history_text = "\n\n".join(
             f"Time: {entry['timestamp']}\nFile: {entry['audio_file']}\nTranscript: {entry['transcript']}"
             for entry in history

--- a/GTKUI/Utils/style.css
+++ b/GTKUI/Utils/style.css
@@ -1,7 +1,12 @@
 /* Label Styling */
 label {
-    color: white;
+    color: #222222;
     font-size: 14px;
+}
+
+.sidebar label,
+.chat-page label {
+    color: white;
 }
 
 /* Persona Label Styling */


### PR DESCRIPTION
## Summary
- scope the white label color to dark-themed containers and add a default tone for unstyled windows
- ensure message dialogs and persona info popups apply the shared CSS and dark theme classes with graceful fallbacks

## Testing
- `pytest tests/test_provider_manager.py -q` *(fails: Gtk stub lacks CssProvider in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc895071bc83228cc5130622a71bba