### PR TITLE
Style sidebar notebooks for the dark theme

### DIFF
--- a/GTKUI/Provider_manager/Settings/Anthropic_settings.py
+++ b/GTKUI/Provider_manager/Settings/Anthropic_settings.py
@@ -40,6 +40,7 @@ class AnthropicSettingsWindow(Gtk.Window):
         self.set_child(container)
 
         notebook = Gtk.Notebook()
+        notebook.get_style_context().add_class("sidebar-notebook")
         notebook.set_hexpand(True)
         notebook.set_vexpand(True)
         container.append(notebook)

--- a/GTKUI/Provider_manager/Settings/Google_settings.py
+++ b/GTKUI/Provider_manager/Settings/Google_settings.py
@@ -100,6 +100,7 @@ class GoogleSettingsWindow(Gtk.Window):
         }
 
         notebook = Gtk.Notebook()
+        notebook.get_style_context().add_class("sidebar-notebook")
         notebook.set_hexpand(True)
         notebook.set_vexpand(True)
         self.notebook = notebook

--- a/GTKUI/Provider_manager/Settings/HF_settings.py
+++ b/GTKUI/Provider_manager/Settings/HF_settings.py
@@ -64,6 +64,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
 
         # Create a Notebook widget to hold the different settings tabs.
         self.notebook = Gtk.Notebook()
+        self.notebook.get_style_context().add_class("sidebar-notebook")
         self.notebook.set_tooltip_text("Configure Hugging Face provider behavior, models, and credentials.")
         self.notebook.set_hexpand(True)
         self.notebook.set_vexpand(True)
@@ -77,6 +78,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
         
         # Advanced Tab – with sub-notebook for Optimizations, NVMe Offloading and Miscellaneous.
         advanced_optimizations_notebook = Gtk.Notebook()
+        advanced_optimizations_notebook.get_style_context().add_class("sidebar-notebook")
         advanced_optimizations_notebook.set_tooltip_text("Low-level performance options for advanced use.")
         advanced_optimizations = self.create_advanced_optimizations_tab()
         nvme_offloading = self.create_nvme_offloading_tab()
@@ -104,6 +106,7 @@ class HuggingFaceSettingsWindow(Gtk.Window):
         
         # Model Management Tab – contains a sub-notebook for Manage Models and Search & Download.
         models_notebook = Gtk.Notebook()
+        models_notebook.get_style_context().add_class("sidebar-notebook")
         models_notebook.set_tooltip_text("Manage installed models, search and download new ones.")
         model_management = self.create_model_management_tab()
         # Adjust button positions for Load and Unload Model Buttons.

--- a/GTKUI/Provider_manager/Settings/OA_settings.py
+++ b/GTKUI/Provider_manager/Settings/OA_settings.py
@@ -88,6 +88,7 @@ class OpenAISettingsWindow(Gtk.Window):
         scroller.set_child(main_box)
 
         self.settings_notebook = Gtk.Notebook()
+        self.settings_notebook.get_style_context().add_class("sidebar-notebook")
         if hasattr(self.settings_notebook, "set_hexpand"):
             self.settings_notebook.set_hexpand(True)
         if hasattr(self.settings_notebook, "set_vexpand"):

--- a/GTKUI/Settings/Speech/speech_settings.py
+++ b/GTKUI/Settings/Speech/speech_settings.py
@@ -57,6 +57,7 @@ class SpeechSettings(Gtk.Window):
 
         # Notebook for tabs.
         self.notebook = Gtk.Notebook()
+        self.notebook.get_style_context().add_class("sidebar-notebook")
         vbox.append(self.notebook)
 
         # Keep track of unsaved changes per tab using tab indices.

--- a/GTKUI/Utils/style.css
+++ b/GTKUI/Utils/style.css
@@ -107,6 +107,77 @@ window.chat-page {
     background-color: #2b2b2b;
 }
 
+/* Sidebar Notebook Styling */
+.sidebar notebook,
+.sidebar notebook notebook,
+.sidebar notebook notebook notebook,
+.sidebar notebook .sidebar-notebook {
+    background-color: #1f1f1f;
+    border: 1px solid #3a3a3a;
+    border-radius: 10px;
+}
+
+.sidebar notebook > header,
+.sidebar notebook notebook > header,
+.sidebar notebook notebook notebook > header,
+.sidebar notebook .sidebar-notebook > header {
+    background-color: #252525;
+    border-bottom: 1px solid #3a3a3a;
+    padding: 0 8px;
+}
+
+.sidebar notebook tab,
+.sidebar notebook notebook tab,
+.sidebar notebook notebook notebook tab,
+.sidebar notebook .sidebar-notebook tab {
+    background-color: #2d2d2d;
+    color: #dcdcdc;
+    border-radius: 8px 8px 0 0;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: none;
+    padding: 6px 12px;
+    margin-right: 4px;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.sidebar notebook tab:hover,
+.sidebar notebook notebook tab:hover,
+.sidebar notebook notebook notebook tab:hover,
+.sidebar notebook .sidebar-notebook tab:hover {
+    background-color: #3a3a3a;
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.18);
+}
+
+.sidebar notebook tab:checked,
+.sidebar notebook notebook tab:checked,
+.sidebar notebook notebook notebook tab:checked,
+.sidebar notebook .sidebar-notebook tab:checked {
+    background-color: #444444;
+    color: #ffffff;
+    border-color: #555555;
+}
+
+.sidebar notebook tab label,
+.sidebar notebook notebook tab label,
+.sidebar notebook notebook notebook tab label,
+.sidebar notebook .sidebar-notebook tab label {
+    color: inherit;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+
+.sidebar notebook tab:hover label,
+.sidebar notebook notebook tab:hover label,
+.sidebar notebook notebook notebook tab:hover label,
+.sidebar notebook .sidebar-notebook tab:hover label,
+.sidebar notebook tab:checked label,
+.sidebar notebook notebook tab:checked label,
+.sidebar notebook notebook notebook tab:checked label,
+.sidebar notebook .sidebar-notebook tab:checked label {
+    color: #ffffff;
+}
+
 /* Icon Styling */
 .icon {
     margin: 5px;


### PR DESCRIPTION
## Summary
- apply a dark-themed treatment to sidebar notebooks, tabs, and headers with hover and selected states
- tag GTK settings notebooks with a `sidebar-notebook` class so nested tab stacks inherit the new styling

## Testing
- python -m compileall ATLAS/GTKUI

------
https://chatgpt.com/codex/tasks/task_e_68dc8ab416288322ae6e021d67b91b73