### PR TITLE
Fix scrolled window background styling

### DIFF
--- a/GTKUI/Utils/style.css
+++ b/GTKUI/Utils/style.css
@@ -207,7 +207,9 @@ window.chat-page {
 }
 
 /* Scrollable Content Styling */
-scrollable {
+scrolledwindow,
+scrolledwindow > viewport,
+scrolledwindow > viewport > * {
     background-color: #2b2b2b;
     color: white;
     padding: 8px;


### PR DESCRIPTION
## Summary
- replace the generic scrollable selector with explicit scrolledwindow viewport selectors so dark backgrounds inherit correctly

## Testing
- python main.py *(fails: ModuleNotFoundError: No module named 'gi')*


------
https://chatgpt.com/codex/tasks/task_e_68dc912c48848322909de7a901cf10d6