### PR TITLE
Improve sidebar text contrast

### DIFF
--- a/GTKUI/Utils/style.css
+++ b/GTKUI/Utils/style.css
@@ -1,12 +1,14 @@
 /* Label Styling */
 label {
-    color: #222222;
     font-size: 14px;
 }
 
-.sidebar label,
-.chat-page label {
-    color: white;
+/* Ensure dark-themed windows inherit readable text colors */
+window.sidebar,
+window.sidebar *,
+window.chat-page,
+window.chat-page * {
+    color: #f0f0f0;
 }
 
 /* Persona Label Styling */


### PR DESCRIPTION
## Summary
- ensure dark sidebar and chat-page windows inherit a light, high-contrast text color
- remove the global dark label color so content follows the safer sidebar defaults

## Testing
- python main.py *(fails: ModuleNotFoundError: No module named 'gi')*

------
https://chatgpt.com/codex/tasks/task_e_68dc94cab7a88322b287fc7c92dea89b