### PR TITLE
Ensure settings descendants use dark background

### DIFF
--- a/GTKUI/Utils/style.css
+++ b/GTKUI/Utils/style.css
@@ -104,6 +104,14 @@ window.sidebar {
     background-color: #2b2b2b;
 }
 
+/* Ensure descendant layout widgets inherit the same dark styling */
+window.sidebar scrolledwindow,
+window.sidebar scrolledwindow > viewport,
+window.sidebar box,
+window.sidebar notebook {
+    background-color: #2b2b2b;
+}
+
 /* Chat Page Window styling */
 window.chat-page {
     background-color: #2b2b2b;


### PR DESCRIPTION
## Summary
- ensure the settings window descendant layout widgets reuse the dark sidebar background so all levels match the theme

## Testing
- not run (GUI environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc96c2460883228f2b128a43dc2781