### PR TITLE
Fix scrolled window behavior in provider and persona dialogs

### DIFF
--- a/GTKUI/Persona_manager/persona_management.py
+++ b/GTKUI/Persona_manager/persona_management.py
@@ -110,7 +110,6 @@ class PersonaManagement:
         # Container inside a scrolled window so long persona lists remain usable
         scroll = Gtk.ScrolledWindow()
         scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        scroll.set_propagate_natural_height(True)
         scroll.set_hexpand(True)
         scroll.set_vexpand(True)
         self.persona_window.set_child(scroll)

--- a/GTKUI/Provider_manager/provider_management.py
+++ b/GTKUI/Provider_manager/provider_management.py
@@ -80,7 +80,6 @@ class ProviderManagement:
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        scrolled.set_propagate_natural_height(True)
         scrolled.set_hexpand(True)
         scrolled.set_vexpand(True)
         self.provider_window.set_child(scrolled)


### PR DESCRIPTION
## Summary
- ensure the provider dialog scrolled window constrains its height so overflow triggers scrolling
- update the persona dialog scroller to rely on its own constraints rather than natural height propagation

## Testing
- not run (GTK UI not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc98d701108322bda7d4ae7cdd11df