### PR TITLE
Allow provider-default max tokens for Mistral

### DIFF
--- a/tests/test_mistral_generator.py
+++ b/tests/test_mistral_generator.py
@@ -157,6 +157,65 @@ def test_mistral_generator_applies_config_defaults():
     assert kwargs["tool_choice"] == "none"
 
 
+def test_mistral_generator_omits_max_tokens_when_using_provider_default():
+    settings = {
+        "model": "mistral-large-latest",
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "max_tokens": None,
+        "safe_prompt": False,
+        "random_seed": None,
+        "frequency_penalty": 0.0,
+        "presence_penalty": 0.0,
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+    }
+
+    generator = mistral_module.MistralGenerator(DummyConfig(settings))
+
+    async def exercise():
+        return await generator.generate_response(
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=False,
+        )
+
+    result = asyncio.run(exercise())
+
+    assert result == "ok"
+    kwargs = _StubChat.last_complete_kwargs
+    assert "max_tokens" not in kwargs
+
+
+def test_mistral_generator_treats_zero_override_as_provider_default():
+    settings = {
+        "model": "mistral-large-latest",
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "max_tokens": 2048,
+        "safe_prompt": False,
+        "random_seed": None,
+        "frequency_penalty": 0.0,
+        "presence_penalty": 0.0,
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+    }
+
+    generator = mistral_module.MistralGenerator(DummyConfig(settings))
+
+    async def exercise():
+        return await generator.generate_response(
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=False,
+            max_tokens=0,
+        )
+
+    result = asyncio.run(exercise())
+
+    assert result == "ok"
+    kwargs = _StubChat.last_complete_kwargs
+    assert "max_tokens" not in kwargs
+
+
 def test_mistral_generator_translates_functions_to_tools():
     settings = {
         "model": "mistral-large-latest",

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -704,7 +704,7 @@ class DummyConfig:
             "model": "mistral-large-latest",
             "temperature": 0.0,
             "top_p": 1.0,
-            "max_tokens": 4096,
+            "max_tokens": None,
             "safe_prompt": False,
             "random_seed": None,
             "frequency_penalty": 0.0,
@@ -904,7 +904,11 @@ class DummyConfig:
         if max_tokens in ("", None):
             self._mistral_settings["max_tokens"] = None
         elif max_tokens is not None:
-            self._mistral_settings["max_tokens"] = int(max_tokens)
+            numeric = int(max_tokens)
+            if numeric <= 0:
+                self._mistral_settings["max_tokens"] = None
+            else:
+                self._mistral_settings["max_tokens"] = numeric
         if safe_prompt is not None:
             self._mistral_settings["safe_prompt"] = bool(safe_prompt)
         if random_seed in ("", None):
@@ -2528,6 +2532,14 @@ def test_mistral_settings_window_round_trips_defaults(provider_manager, monkeypa
     assert stored["random_seed"] == 0
     assert stored["tool_choice"] == "none"
     assert window._last_message[0] == "Success"
+
+    window.max_tokens_spin.set_value(0)
+
+    window.on_save_clicked(None)
+
+    stored = config.get_mistral_llm_settings()
+    assert stored["max_tokens"] is None
+    assert window.max_tokens_spin.get_value_as_int() == 0
 
 
 def test_anthropic_settings_window_saves_api_key(provider_manager):


### PR DESCRIPTION
## Summary
- persist `None` for Mistral max token defaults and treat empty/zero values as provider-managed limits
- let the Mistral generator omit `max_tokens` when unset so the API enforces its own ceiling
- keep the GTK Mistral settings UI showing 0 for provider defaults and extend the related tests

## Testing
- pytest tests/test_mistral_generator.py tests/test_provider_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb53f808c8322b4a2825869e38b06