### PR TITLE
Add configurable streaming defaults for Mistral provider

### DIFF
--- a/ATLAS/config.py
+++ b/ATLAS/config.py
@@ -1093,6 +1093,7 @@ class ConfigManager:
             'top_p': 1.0,
             'max_tokens': None,
             'safe_prompt': False,
+            'stream': True,
             'random_seed': None,
             'frequency_penalty': 0.0,
             'presence_penalty': 0.0,
@@ -1165,6 +1166,10 @@ class ConfigManager:
                 stored.get('safe_prompt'),
                 default=bool(defaults['safe_prompt']),
             )
+            merged['stream'] = _coerce_bool(
+                stored.get('stream'),
+                default=bool(defaults['stream']),
+            )
             merged['parallel_tool_calls'] = _coerce_bool(
                 stored.get('parallel_tool_calls'),
                 default=bool(defaults['parallel_tool_calls']),
@@ -1209,6 +1214,7 @@ class ConfigManager:
         top_p: Optional[float] = None,
         max_tokens: Optional[int] = None,
         safe_prompt: Optional[bool] = None,
+        stream: Optional[bool] = None,
         random_seed: Optional[Any] = None,
         frequency_penalty: Optional[float] = None,
         presence_penalty: Optional[float] = None,
@@ -1313,6 +1319,10 @@ class ConfigManager:
         normalized_safe_prompt = _normalize_bool(safe_prompt)
         if normalized_safe_prompt is not None:
             settings['safe_prompt'] = normalized_safe_prompt
+
+        normalized_stream = _normalize_bool(stream)
+        if normalized_stream is not None:
+            settings['stream'] = normalized_stream
 
         normalized_parallel = _normalize_bool(parallel_tool_calls)
         if normalized_parallel is not None:

--- a/GTKUI/Provider_manager/Settings/Mistral_settings.py
+++ b/GTKUI/Provider_manager/Settings/Mistral_settings.py
@@ -148,6 +148,15 @@ class MistralSettingsWindow(Gtk.Window):
         grid.attach(self.safe_prompt_toggle, 1, row, 1, 1)
 
         row += 1
+        stream_label = Gtk.Label(label="Streaming:")
+        stream_label.set_xalign(0.0)
+        grid.attach(stream_label, 0, row, 1, 1)
+
+        self.stream_toggle = Gtk.CheckButton(label="Stream responses by default")
+        self.stream_toggle.set_halign(Gtk.Align.START)
+        grid.attach(self.stream_toggle, 1, row, 1, 1)
+
+        row += 1
         parallel_label = Gtk.Label(label="Parallel tool calls:")
         parallel_label.set_xalign(0.0)
         grid.attach(parallel_label, 0, row, 1, 1)
@@ -208,6 +217,7 @@ class MistralSettingsWindow(Gtk.Window):
         self.max_tokens_spin.set_value(float(max_tokens or 0))
 
         self.safe_prompt_toggle.set_active(bool(settings.get("safe_prompt", False)))
+        self.stream_toggle.set_active(bool(settings.get("stream", True)))
         self.parallel_tool_calls_toggle.set_active(
             bool(settings.get("parallel_tool_calls", True))
         )
@@ -281,6 +291,7 @@ class MistralSettingsWindow(Gtk.Window):
                 top_p=self.top_p_spin.get_value(),
                 max_tokens=max_tokens,
                 safe_prompt=self.safe_prompt_toggle.get_active(),
+                stream=self.stream_toggle.get_active(),
                 random_seed=random_seed,
                 frequency_penalty=self.frequency_penalty_spin.get_value(),
                 presence_penalty=self.presence_penalty_spin.get_value(),

--- a/modules/Providers/Mistral/Mistral_gen_response.py
+++ b/modules/Providers/Mistral/Mistral_gen_response.py
@@ -169,6 +169,11 @@ class MistralGenerator:
                 'safe_prompt',
                 False,
             )
+            effective_stream = _resolve_bool(
+                stream,
+                'stream',
+                True,
+            )
             effective_parallel = _resolve_bool(
                 parallel_tool_calls,
                 'parallel_tool_calls',
@@ -228,10 +233,7 @@ class MistralGenerator:
                 if configured_tool_choice is not None:
                     request_kwargs['tool_choice'] = configured_tool_choice
 
-            if stream is None:
-                stream = bool(settings.get('stream', True))
-
-            if stream:
+            if effective_stream:
                 response_stream = await asyncio.to_thread(
                     self.client.chat.stream,
                     **request_kwargs,

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -706,6 +706,7 @@ class DummyConfig:
             "top_p": 1.0,
             "max_tokens": None,
             "safe_prompt": False,
+            "stream": True,
             "random_seed": None,
             "frequency_penalty": 0.0,
             "presence_penalty": 0.0,
@@ -893,6 +894,7 @@ class DummyConfig:
         presence_penalty=None,
         tool_choice=None,
         parallel_tool_calls=None,
+        stream=None,
     ):
         if model:
             self._mistral_settings["model"] = model
@@ -911,6 +913,8 @@ class DummyConfig:
                 self._mistral_settings["max_tokens"] = numeric
         if safe_prompt is not None:
             self._mistral_settings["safe_prompt"] = bool(safe_prompt)
+        if stream is not None:
+            self._mistral_settings["stream"] = bool(stream)
         if random_seed in ("", None):
             self._mistral_settings["random_seed"] = None
         elif random_seed is not None:
@@ -2456,6 +2460,7 @@ def test_mistral_settings_window_round_trips_defaults(provider_manager, monkeypa
         top_p=0.8,
         max_tokens=2048,
         safe_prompt=True,
+        stream=False,
         random_seed=1234,
         frequency_penalty=0.15,
         presence_penalty=-0.3,
@@ -2478,6 +2483,7 @@ def test_mistral_settings_window_round_trips_defaults(provider_manager, monkeypa
     assert math.isclose(window.presence_penalty_spin.get_value(), -0.3)
     assert window.max_tokens_spin.get_value_as_int() == 2048
     assert window.safe_prompt_toggle.get_active() is True
+    assert window.stream_toggle.get_active() is False
     assert window.parallel_tool_calls_toggle.get_active() is False
     assert window.random_seed_entry.get_text() == "1234"
     assert json.loads(window.tool_choice_entry.get_text()) == {"name": "math", "type": "function"}
@@ -2488,6 +2494,7 @@ def test_mistral_settings_window_round_trips_defaults(provider_manager, monkeypa
         top_p=0.6,
         max_tokens=None,
         safe_prompt=False,
+        stream=True,
         random_seed=None,
         frequency_penalty=0.0,
         presence_penalty=0.0,
@@ -2502,6 +2509,7 @@ def test_mistral_settings_window_round_trips_defaults(provider_manager, monkeypa
     assert math.isclose(window.top_p_spin.get_value(), 0.6)
     assert window.max_tokens_spin.get_value_as_int() == 0
     assert window.safe_prompt_toggle.get_active() is False
+    assert window.stream_toggle.get_active() is True
     assert window.parallel_tool_calls_toggle.get_active() is True
     assert window.random_seed_entry.get_text() == ""
     assert window.tool_choice_entry.get_text() == "auto"
@@ -2513,6 +2521,7 @@ def test_mistral_settings_window_round_trips_defaults(provider_manager, monkeypa
     window.presence_penalty_spin.set_value(0.35)
     window.max_tokens_spin.set_value(1024)
     window.safe_prompt_toggle.set_active(True)
+    window.stream_toggle.set_active(False)
     window.parallel_tool_calls_toggle.set_active(True)
     window.random_seed_entry.set_text("0")
     window.tool_choice_entry.set_text("none")
@@ -2528,6 +2537,7 @@ def test_mistral_settings_window_round_trips_defaults(provider_manager, monkeypa
     assert math.isclose(stored["presence_penalty"], 0.35)
     assert stored["max_tokens"] == 1024
     assert stored["safe_prompt"] is True
+    assert stored["stream"] is False
     assert stored["parallel_tool_calls"] is True
     assert stored["random_seed"] == 0
     assert stored["tool_choice"] == "none"


### PR DESCRIPTION
## Summary
- persist a `stream` flag with the Mistral LLM defaults and validate it during updates
- surface a "Stream responses by default" toggle in the Mistral settings window
- resolve the stream behaviour from the stored default when generating responses and expand the tests

## Testing
- pytest tests/test_mistral_generator.py tests/test_provider_manager.py -k mistral

------
https://chatgpt.com/codex/tasks/task_e_68ddb6c6e52c8322a665ebe2546fd3b8