### PR TITLE
Support configurable Mistral stop sequences

### DIFF
--- a/ATLAS/config.py
+++ b/ATLAS/config.py
@@ -1099,6 +1099,7 @@ class ConfigManager:
             'presence_penalty': 0.0,
             'tool_choice': 'auto',
             'parallel_tool_calls': True,
+            'stop_sequences': [],
         }
 
         stored = self.get_config('MISTRAL_LLM')
@@ -1201,6 +1202,13 @@ class ConfigManager:
             else:
                 merged['tool_choice'] = defaults['tool_choice']
 
+            try:
+                merged['stop_sequences'] = self._coerce_stop_sequences(
+                    stored.get('stop_sequences')
+                )
+            except ValueError:
+                merged['stop_sequences'] = list(defaults['stop_sequences'])
+
             return merged
 
         return dict(defaults)
@@ -1220,6 +1228,7 @@ class ConfigManager:
         presence_penalty: Optional[float] = None,
         tool_choice: Optional[Any] = None,
         parallel_tool_calls: Optional[bool] = None,
+        stop_sequences: Any = _UNSET,
     ) -> Dict[str, Any]:
         """Persist default configuration for the Mistral chat provider."""
 
@@ -1355,6 +1364,9 @@ class ConfigManager:
         )
 
         settings['tool_choice'] = _normalize_tool_choice(tool_choice)
+
+        if stop_sequences is not _UNSET:
+            settings['stop_sequences'] = self._coerce_stop_sequences(stop_sequences)
 
         self.yaml_config['MISTRAL_LLM'] = copy.deepcopy(settings)
         self.config['MISTRAL_LLM'] = copy.deepcopy(settings)


### PR DESCRIPTION
## Summary
- add stop sequence support to the stored Mistral defaults and validation
- expose a stop sequence entry field in the GTK Mistral settings window
- forward configured stop sequences to the mistralai client and extend tests

## Testing
- pytest tests/test_mistral_generator.py
- pytest tests/test_provider_manager.py -k mistral --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68ddb86dce00832280b2a003423d4b4e