### PR TITLE
Add prompt mode configuration for Mistral provider

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -563,6 +563,7 @@ def test_get_mistral_llm_settings_includes_json_defaults(config_manager):
     assert snapshot["retry_min_seconds"] == 4
     assert snapshot["retry_max_seconds"] == 10
     assert snapshot["base_url"] is None
+    assert snapshot["prompt_mode"] is None
 
 
 def test_set_mistral_llm_settings_handles_json_options(config_manager):
@@ -592,6 +593,33 @@ def test_set_mistral_llm_settings_handles_json_options(config_manager):
 
     stored = config_manager.config["MISTRAL_LLM"]
     assert stored["json_schema"] is None
+
+
+def test_set_mistral_llm_settings_tracks_prompt_mode(config_manager):
+    saved = config_manager.set_mistral_llm_settings(
+        model="mistral-large-latest",
+        prompt_mode="reasoning",
+    )
+
+    assert saved["prompt_mode"] == "reasoning"
+    snapshot = config_manager.get_mistral_llm_settings()
+    assert snapshot["prompt_mode"] == "reasoning"
+
+    saved = config_manager.set_mistral_llm_settings(
+        model="mistral-large-latest",
+        prompt_mode=None,
+    )
+
+    assert saved["prompt_mode"] is None
+    assert config_manager.get_mistral_llm_settings()["prompt_mode"] is None
+
+
+def test_set_mistral_llm_settings_rejects_invalid_prompt_mode(config_manager):
+    with pytest.raises(ValueError):
+        config_manager.set_mistral_llm_settings(
+            model="mistral-large-latest",
+            prompt_mode="unsupported",
+        )
 
 
 def test_set_mistral_llm_settings_updates_retry_policy(config_manager):


### PR DESCRIPTION
## Summary
- add prompt mode persistence and validation to the Mistral configuration layer and forward the value in generator requests
- expose a prompt mode selector in the GTK settings window alongside existing sampling controls
- cover the new option with unit tests for configuration, UI round-tripping, and request dispatch

## Testing
- pytest tests/test_config_manager.py::test_set_mistral_llm_settings_tracks_prompt_mode tests/test_config_manager.py::test_set_mistral_llm_settings_rejects_invalid_prompt_mode tests/test_provider_manager.py::test_mistral_settings_window_round_trips_defaults tests/test_mistral_generator.py::test_mistral_generator_includes_prompt_mode_when_configured


------
https://chatgpt.com/codex/tasks/task_e_68df30cd706c83228e1b454780fd5971