### PR TITLE
Refactor speech manager for lazy provider creation

### DIFF
--- a/tests/test_speech_manager.py
+++ b/tests/test_speech_manager.py
@@ -374,11 +374,15 @@ def test_get_tts_provider_names_returns_ordered_copy(speech_manager):
 
     names = speech_manager.get_tts_provider_names()
 
-    assert names == ("alpha", "beta")
+    assert isinstance(names, tuple)
+    assert names[:2] == ("alpha", "beta")
+    assert "gamma" not in names
+    assert "eleven_labs" in names
 
     speech_manager.tts_services["gamma"] = object()
 
-    assert names == ("alpha", "beta")
+    assert names[:2] == ("alpha", "beta")
+    assert "gamma" not in names
 
 
 def test_resolve_tts_provider_prefers_registered_choice(speech_manager):
@@ -405,11 +409,11 @@ def test_resolve_tts_provider_returns_first_available_when_no_fallback(speech_ma
 
     resolved = speech_manager.resolve_tts_provider(None)
 
-    assert resolved == "google"
+    assert resolved == "eleven_labs"
 
 
 def test_resolve_tts_provider_handles_no_services(speech_manager):
-    assert speech_manager.resolve_tts_provider("whatever") is None
+    assert speech_manager.resolve_tts_provider("whatever") == "eleven_labs"
 
 
 def test_get_stt_provider_names_returns_ordered_copy(speech_manager):
@@ -418,11 +422,15 @@ def test_get_stt_provider_names_returns_ordered_copy(speech_manager):
 
     names = speech_manager.get_stt_provider_names()
 
-    assert names == ("delta", "epsilon")
+    assert isinstance(names, tuple)
+    assert names[:2] == ("delta", "epsilon")
+    assert "zeta" not in names
+    assert "google" in names
 
     speech_manager.stt_services["zeta"] = object()
 
-    assert names == ("delta", "epsilon")
+    assert names[:2] == ("delta", "epsilon")
+    assert "zeta" not in names
 
 
 def test_get_default_tts_provider_index_tracks_provider(speech_manager):


### PR DESCRIPTION
## Summary
- refactor `SpeechManager` to register speech provider factories in the constructor and lazily instantiate providers via `get_tts_provider` and `get_stt_provider`
- add caching helpers, google factory aliases, and default-handling logic so providers are created on demand and reuse instances once initialized
- update speech manager tests to validate the new lazy initialization behavior and dynamic provider listings

## Testing
- pytest tests/test_speech_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e05e162e8483229be283aae065f787