### PR TITLE
Cache provider generators and add reuse tests

### DIFF
--- a/modules/Providers/Google/GG_gen_response.py
+++ b/modules/Providers/Google/GG_gen_response.py
@@ -19,6 +19,9 @@ from modules.Providers.Google.settings_resolver import GoogleSettingsResolver
 from modules.logging.logger import setup_logger
 
 
+_GOOGLE_GENERATOR_INSTANCE: Optional["GoogleGeminiGenerator"] = None
+
+
 class GoogleGeminiGenerator:
     def __init__(self, config_manager: ConfigManager):
         self.config_manager = config_manager
@@ -683,7 +686,7 @@ class GoogleGeminiGenerator:
 
 
 def setup_google_gemini_generator(config_manager: ConfigManager):
-    return GoogleGeminiGenerator(config_manager)
+    return get_google_gemini_generator(config_manager)
 
 
 async def generate_response(
@@ -705,7 +708,7 @@ async def generate_response(
     system_instruction: Optional[str] = None,
     enable_functions: bool = True,
 ):
-    generator = setup_google_gemini_generator(config_manager)
+    generator = get_google_gemini_generator(config_manager)
     return await generator.generate_response(
         messages=messages,
         model=model,
@@ -736,4 +739,16 @@ async def process_response(response: Union[str, AsyncIterator[str]]) -> str:
         return full_response
     else:
         raise ValueError(f"Unexpected response type: {type(response)}")
+
+
+def get_google_gemini_generator(config_manager: ConfigManager) -> GoogleGeminiGenerator:
+    global _GOOGLE_GENERATOR_INSTANCE
+    if _GOOGLE_GENERATOR_INSTANCE is None:
+        _GOOGLE_GENERATOR_INSTANCE = GoogleGeminiGenerator(config_manager)
+    return _GOOGLE_GENERATOR_INSTANCE
+
+
+def reset_google_gemini_generator_cache() -> None:
+    global _GOOGLE_GENERATOR_INSTANCE
+    _GOOGLE_GENERATOR_INSTANCE = None
 

--- a/modules/Providers/Mistral/Mistral_gen_response.py
+++ b/modules/Providers/Mistral/Mistral_gen_response.py
@@ -20,6 +20,8 @@ from modules.logging.logger import setup_logger
 
 _SUPPORTED_PROMPT_MODES = {"reasoning"}
 
+_MISTRAL_GENERATOR_INSTANCE: Optional["MistralGenerator"] = None
+
 class MistralGenerator:
     def __init__(self, config_manager: ConfigManager):
         self.config_manager = config_manager
@@ -908,7 +910,7 @@ class MistralGenerator:
             return full_response
 
 def setup_mistral_generator(config_manager: ConfigManager):
-    return MistralGenerator(config_manager)
+    return get_mistral_generator(config_manager)
 
 async def generate_response(
     config_manager: ConfigManager,
@@ -920,7 +922,7 @@ async def generate_response(
     current_persona=None,
     functions=None,
 ) -> Union[str, AsyncIterator[str]]:
-    generator = setup_mistral_generator(config_manager)
+    generator = get_mistral_generator(config_manager)
     return await generator.generate_response(messages, model, max_tokens, temperature, stream, current_persona, functions)
 
 async def process_response(response: Union[str, AsyncIterator[str]]) -> str:
@@ -948,3 +950,15 @@ def generate_response_sync(config_manager: ConfigManager, messages: List[Dict[st
     if stream:
         return loop.run_until_complete(process_response(response))
     return response
+
+
+def get_mistral_generator(config_manager: ConfigManager) -> MistralGenerator:
+    global _MISTRAL_GENERATOR_INSTANCE
+    if _MISTRAL_GENERATOR_INSTANCE is None:
+        _MISTRAL_GENERATOR_INSTANCE = MistralGenerator(config_manager)
+    return _MISTRAL_GENERATOR_INSTANCE
+
+
+def reset_mistral_generator_cache() -> None:
+    global _MISTRAL_GENERATOR_INSTANCE
+    _MISTRAL_GENERATOR_INSTANCE = None

--- a/modules/Providers/OpenAI/OA_gen_response.py
+++ b/modules/Providers/OpenAI/OA_gen_response.py
@@ -16,6 +16,9 @@ from ATLAS.ToolManager import (
     use_tool
 )
 
+_OPENAI_GENERATOR_INSTANCE: Optional["OpenAIGenerator"] = None
+
+
 class OpenAIGenerator:
     def __init__(self, config_manager: ConfigManager):
         self.config_manager = config_manager
@@ -1441,7 +1444,7 @@ async def generate_response(
     json_mode: Optional[Any] = None,
     json_schema: Optional[Any] = None
 ) -> Union[str, AsyncIterator[str]]:
-    generator = OpenAIGenerator(config_manager)
+    generator = get_openai_generator(config_manager)
     return await generator.generate_response(
         messages,
         model,
@@ -1464,6 +1467,18 @@ async def generate_response(
         json_mode,
         json_schema
     )
+
+
+def get_openai_generator(config_manager: ConfigManager) -> OpenAIGenerator:
+    global _OPENAI_GENERATOR_INSTANCE
+    if _OPENAI_GENERATOR_INSTANCE is None:
+        _OPENAI_GENERATOR_INSTANCE = OpenAIGenerator(config_manager)
+    return _OPENAI_GENERATOR_INSTANCE
+
+
+def reset_openai_generator_cache() -> None:
+    global _OPENAI_GENERATOR_INSTANCE
+    _OPENAI_GENERATOR_INSTANCE = None
 
 async def process_streaming_response(response: AsyncIterator[Dict]) -> str:
     content = ""


### PR DESCRIPTION
## Summary
- cache generator instances for OpenAI, Mistral, and Google within ProviderManager and reuse bound methods
- add generator cache helpers to provider modules and clear them on credential updates
- extend provider manager tests with generator stubs and regression checks to ensure generators are only constructed once

## Testing
- pytest tests/test_provider_manager.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e06a56ddbc8322a77251e7b1c20d7c