### PR TITLE
Lazy-load ToolManager config manager

### DIFF
--- a/ATLAS/ToolManager.py
+++ b/ATLAS/ToolManager.py
@@ -6,11 +6,10 @@ import inspect
 import importlib.util
 import sys
 from datetime import datetime
-from ATLAS.config import ConfigManager
 from modules.logging.logger import setup_logger
 from modules.Tools.tool_event_system import event_system
 
-config_manager = ConfigManager()
+from ATLAS.config import ConfigManager
 logger = setup_logger(__name__)
 
 def get_required_args(function):
@@ -83,10 +82,14 @@ async def use_tool(
     frequency_penalty_var,
     presence_penalty_var,
     conversation_manager,
-    config_manager
+    config_manager=None
 ):
     logger.info(f"use_tool called for user: {user}, conversation_id: {conversation_id}")
     logger.info(f"Message received: {message}")
+
+    if config_manager is None:
+        logger.debug("No ConfigManager supplied to use_tool; instantiating a new one lazily.")
+        config_manager = ConfigManager()
 
     if not isinstance(message, dict):
         normalized_message = {}
@@ -234,10 +237,14 @@ async def call_model_with_new_prompt(
     frequency_penalty_var,
     presence_penalty_var,
     functions,
-    config_manager
+    config_manager=None
 ):
     logger.info("Calling model with new prompt after function execution.")
     logger.info(f"Prompt: {prompt}")
+
+    if config_manager is None:
+        logger.debug("No ConfigManager supplied to call_model_with_new_prompt; instantiating a new one lazily.")
+        config_manager = ConfigManager()
     
     try:
         response = await config_manager.provider_manager.generate_response(

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -1,0 +1,139 @@
+import asyncio
+import importlib
+import json
+import sys
+import types
+
+
+def _clear_provider_env(monkeypatch):
+    for key in [
+        "OPENAI_API_KEY",
+        "MISTRAL_API_KEY",
+        "GOOGLE_API_KEY",
+        "HUGGINGFACE_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GROK_API_KEY",
+        "XI_API_KEY",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _ensure_yaml(monkeypatch):
+    if "yaml" in sys.modules:
+        return
+
+    yaml_stub = types.ModuleType("yaml")
+    yaml_stub.safe_load = lambda stream: {}
+    monkeypatch.setitem(sys.modules, "yaml", yaml_stub)
+
+
+def _ensure_dotenv(monkeypatch):
+    if "dotenv" in sys.modules:
+        return
+
+    dotenv_stub = types.ModuleType("dotenv")
+
+    def _load_dotenv(*_args, **_kwargs):  # pragma: no cover - stub helper
+        return True
+
+    def _set_key(*_args, **_kwargs):  # pragma: no cover - stub helper
+        return None
+
+    def _find_dotenv(*_args, **_kwargs):  # pragma: no cover - stub helper
+        return ""
+
+    dotenv_stub.load_dotenv = _load_dotenv
+    dotenv_stub.set_key = _set_key
+    dotenv_stub.find_dotenv = _find_dotenv
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv_stub)
+
+
+def test_tool_manager_import_without_credentials(monkeypatch):
+    """Importing ToolManager should not require configuration credentials."""
+
+    _clear_provider_env(monkeypatch)
+    _ensure_yaml(monkeypatch)
+    _ensure_dotenv(monkeypatch)
+    sys.modules.pop("ATLAS.ToolManager", None)
+
+    module = importlib.import_module("ATLAS.ToolManager")
+
+    assert hasattr(module, "use_tool"), "ToolManager module should expose use_tool"
+
+
+def test_use_tool_prefers_supplied_config_manager(monkeypatch):
+    _ensure_yaml(monkeypatch)
+    _ensure_dotenv(monkeypatch)
+    tool_manager = importlib.import_module("ATLAS.ToolManager")
+    tool_manager = importlib.reload(tool_manager)
+
+    class DummyConversationHistory:
+        def __init__(self):
+            self.history = [{"role": "user", "content": "Hi"}]
+            self.responses = []
+            self.messages = []
+
+        def add_response(self, user, conversation_id, response, timestamp):
+            self.responses.append((user, conversation_id, response, timestamp))
+            self.history.append({"role": "function", "name": "tool", "content": str(response)})
+
+        def add_message(self, user, conversation_id, role, content, timestamp):
+            self.messages.append((user, conversation_id, role, content, timestamp))
+            self.history.append({"role": role, "content": content})
+
+        def get_history(self, user, conversation_id):
+            return list(self.history)
+
+    class DummyProviderManager:
+        def __init__(self):
+            self.generate_calls = []
+
+        def get_current_model(self):
+            return "dummy-model"
+
+        async def generate_response(self, **kwargs):
+            self.generate_calls.append(kwargs)
+            return "model-output"
+
+    class DummyConfigManager:
+        def __init__(self):
+            self.provider_manager = DummyProviderManager()
+
+    conversation_history = DummyConversationHistory()
+    dummy_config = DummyConfigManager()
+
+    async def echo_tool(value):
+        return value
+
+    message = {
+        "function_call": {
+            "name": "echo_tool",
+            "arguments": json.dumps({"value": "ping"}),
+        }
+    }
+
+    function_map = {"echo_tool": echo_tool}
+
+    async def run_test():
+        response = await tool_manager.use_tool(
+            user="user",
+            conversation_id="conversation",
+            message=message,
+            conversation_history=conversation_history,
+            function_map=function_map,
+            functions=None,
+            current_persona=None,
+            temperature_var=0.5,
+            top_p_var=0.9,
+            frequency_penalty_var=0.0,
+            presence_penalty_var=0.0,
+            conversation_manager=conversation_history,
+            config_manager=dummy_config,
+        )
+
+        assert response == "model-output"
+        assert (
+            dummy_config.provider_manager.generate_calls
+        ), "Supplied config manager should be used"
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- instantiate the ToolManager ConfigManager lazily to avoid import-time failures
- ensure use_tool and call_model_with_new_prompt fall back to creating a ConfigManager only when needed
- add tests validating ToolManager import without credentials and that supplied config managers are honored

## Testing
- pytest tests/test_tool_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e071905e6c8322b24bbe7eb47d03c5