### PR TITLE
Handle missing default provider credentials gracefully

### DIFF
--- a/ATLAS/provider_manager.py
+++ b/ATLAS/provider_manager.py
@@ -105,7 +105,15 @@ class ProviderManager:
         Initializes the provider managers and sets the default provider.
         """
         await self._prime_openai_models()
-        await self.switch_llm_provider(self.current_llm_provider)
+        if self.current_llm_provider and self.config_manager.has_provider_api_key(
+            self.current_llm_provider
+        ):
+            await self.switch_llm_provider(self.current_llm_provider)
+        else:
+            self.logger.warning(
+                "Skipping automatic activation of provider '%s' because its API key is missing.",
+                self.current_llm_provider,
+            )
 
     async def _prime_openai_models(self) -> None:
         """Attempt to refresh cached OpenAI models during startup."""


### PR DESCRIPTION
## Summary
- record deferred warnings in `ConfigManager` when the default provider API key is missing and keep the manager usable
- skip automatic provider activation when credentials are absent, surface the warning in the chat status summary, and keep initialization running
- cover the relaxed behavior with new configuration and status summary tests, expanding dependency stubs as needed

## Testing
- pytest tests/test_config_manager.py tests/test_atlas_status.py

------
https://chatgpt.com/codex/tasks/task_e_68e075db1f1883229b02dbe62865e85b