### PR TITLE
Cache persona tool maps

### DIFF
--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -3,6 +3,9 @@ import importlib
 import json
 import sys
 import types
+from pathlib import Path
+import shutil
+import textwrap
 
 
 def _clear_provider_env(monkeypatch):
@@ -137,3 +140,52 @@ def test_use_tool_prefers_supplied_config_manager(monkeypatch):
         ), "Supplied config manager should be used"
 
     asyncio.run(run_test())
+
+
+def test_load_function_map_caches_by_persona(monkeypatch):
+    persona_name = "CachePersona"
+    persona_dir = Path("modules/Personas") / persona_name / "Toolbox"
+    maps_path = persona_dir / "maps.py"
+    module_name = f"persona_{persona_name}_maps"
+
+    persona_dir.mkdir(parents=True, exist_ok=True)
+    maps_path.write_text(
+        textwrap.dedent(
+            """
+            EXECUTION_COUNTER = globals().get("EXECUTION_COUNTER", 0) + 1
+
+            def sample_tool():
+                return "ok"
+
+            function_map = {"sample_tool": sample_tool}
+            """
+        )
+    )
+
+    tool_manager = importlib.import_module("ATLAS.ToolManager")
+    monkeypatch.setitem(tool_manager.__dict__, "_function_map_cache", {})
+    sys.modules.pop(module_name, None)
+
+    spec_calls = {"count": 0}
+    original_spec = importlib.util.spec_from_file_location
+
+    def counting_spec(*args, **kwargs):
+        spec_calls["count"] += 1
+        return original_spec(*args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "spec_from_file_location", counting_spec)
+
+    persona_payload = {"name": persona_name}
+
+    try:
+        first_map = tool_manager.load_function_map_from_current_persona(persona_payload)
+        second_map = tool_manager.load_function_map_from_current_persona(persona_payload)
+
+        assert first_map is second_map
+        assert spec_calls["count"] == 1
+
+        module = sys.modules[module_name]
+        assert getattr(module, "EXECUTION_COUNTER", 0) == 1
+    finally:
+        sys.modules.pop(module_name, None)
+        shutil.rmtree(Path("modules/Personas") / persona_name, ignore_errors=True)


### PR DESCRIPTION
## Summary
- reuse cached persona modules when loading ToolManager function maps and support explicit refreshes
- store persona function maps in-memory so repeat lookups avoid disk access
- add regression test ensuring persona tool map loads hit disk only once

## Testing
- pytest tests/test_tool_manager.py


------
https://chatgpt.com/codex/tasks/task_e_68e07ab3e0fc8322b79e04f0ef794538