### PR TITLE
Inject shared config manager into PersonaManager

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -183,7 +183,7 @@ class ATLAS:
         """
         self.provider_manager = await ProviderManager.create(self.config_manager)
         user_identifier, _ = self._ensure_user_identity()
-        self.persona_manager = PersonaManager(master=self, user=user_identifier)
+        self.persona_manager = PersonaManager(master=self, user=user_identifier, config_manager=self.config_manager)
         self.chat_session = ChatSession(self)
 
         default_provider = self.config_manager.get_default_provider()

--- a/ATLAS/persona_manager.py
+++ b/ATLAS/persona_manager.py
@@ -27,10 +27,12 @@ class PersonaManager:
         'travel_guide', 'storyteller', 'game_master', 'chef'
     ]
 
-    def __init__(self, master, user: str):
+    def __init__(self, master, user: str, config_manager: Optional[ConfigManager] = None):
         self.master = master
         self.user = user
-        self.config_manager = ConfigManager()
+        if config_manager is None and hasattr(master, "config_manager"):
+            config_manager = master.config_manager
+        self.config_manager = config_manager or ConfigManager()
         self.logger = setup_logger(__name__)
         self.persona_base_path = os.path.join(os.path.dirname(__file__), '..', 'modules', 'Personas')
         self.persona_names: List[str] = self.load_persona_names(self.persona_base_path)
@@ -76,7 +78,7 @@ class PersonaManager:
             self.logger.info(f"Persona '{persona_name}' retrieved from cache.")
             return self.personas[persona_name]
         
-        persona_folder = os.path.join(self.master.config_manager.get_app_root(), 'modules', 'Personas', persona_name, 'Persona')
+        persona_folder = os.path.join(self.config_manager.get_app_root(), 'modules', 'Personas', persona_name, 'Persona')
         json_file = os.path.join(persona_folder, f'{persona_name}.json')
 
         self.logger.debug(f"Attempting to load persona from folder: {persona_folder}")

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -76,7 +76,7 @@ def persona_manager(tmp_path, monkeypatch):
     monkeypatch.setattr(persona_manager_module, 'UserDataManager', _StubUserDataManager)
 
     master = types.SimpleNamespace(config_manager=_StubConfigManager())
-    manager = PersonaManager(master, user='tester')
+    manager = PersonaManager(master, user='tester', config_manager=master.config_manager)
     manager.persona_base_path = str(personas_dir)
     manager.persona_names = manager.load_persona_names(str(personas_dir))
     return manager, personas_dir


### PR DESCRIPTION
## Summary
- allow PersonaManager to accept an injected ConfigManager and reuse the master's instance by default
- pass the shared ConfigManager from the ATLAS application when creating PersonaManager
- update persona manager tests to construct the manager with the shared configuration stub

## Testing
- pytest tests/test_persona_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e07c2ecc98832299e55f7c16fc4337