### PR TITLE
Fix ffmpeg dependency typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pyyaml
 pygame
 soundfile
 sounddevice
-ffmpg
+ffmpeg
 noisereduce
 pydub
 


### PR DESCRIPTION
## Summary
- correct the ffmpeg package name in requirements.txt so installation succeeds
- verify there were no other references to the misspelled dependency in setup documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e07efa93f88322b1d4271de59699a7