### PR TITLE
Ensure persona reminders trigger on user turns

### DIFF
--- a/modules/Chat/chat_session.py
+++ b/modules/Chat/chat_session.py
@@ -93,7 +93,6 @@ class ChatSession:
             message_entry.update(audio_payload)
 
         self.conversation_history.append(message_entry)
-        self.messages_since_last_reminder += 1
         return response
 
     def run_in_background(

--- a/tests/test_chat_session_reminders.py
+++ b/tests/test_chat_session_reminders.py
@@ -1,0 +1,68 @@
+import asyncio
+import logging
+
+from modules.Chat.chat_session import ChatSession
+
+
+class DummyPersonaManager:
+    def __init__(self, prompt="You are a helpful assistant."):
+        self._prompt = prompt
+
+    def get_current_persona_prompt(self):
+        return self._prompt
+
+
+class DummyProviderManager:
+    async def generate_response(self, *args, **kwargs):
+        return {"text": "Acknowledged."}
+
+
+class DummyAtlas:
+    def __init__(self):
+        self._default_provider = "dummy-provider"
+        self._default_model = "dummy-model"
+        self.logger = logging.getLogger("ChatSessionReminderTests")
+        self.persona_manager = DummyPersonaManager()
+        self.provider_manager = DummyProviderManager()
+        self.tts_calls = []
+
+    def get_default_provider(self):
+        return self._default_provider
+
+    def get_default_model(self):
+        return self._default_model
+
+    async def maybe_text_to_speech(self, response):  # pragma: no cover - simple stub
+        self.tts_calls.append(response)
+
+
+def test_persona_reminder_counts_only_user_messages():
+    atlas = DummyAtlas()
+    session = ChatSession(atlas)
+    session.reminder_interval = 2
+
+    async def exercise():
+        await session.send_message("Hello")
+
+        reminders = [
+            message
+            for message in session.conversation_history
+            if message["role"] == "system"
+            and message["content"].startswith("Remember, you are acting as")
+        ]
+        assert reminders == []
+        assert session.messages_since_last_reminder == 1
+
+        await session.send_message("How are you?")
+
+        reminders = [
+            message
+            for message in session.conversation_history
+            if message["role"] == "system"
+            and message["content"].startswith("Remember, you are acting as")
+        ]
+        assert len(reminders) == 1
+        assert session.messages_since_last_reminder == 0
+
+    asyncio.run(exercise())
+


### PR DESCRIPTION
## Summary
- stop incrementing the persona reminder counter after assistant replies so only user turns advance the reminder interval
- add a regression test covering persona reminder timing and confirming the reminder fires after the configured number of user turns

## Testing
- pytest tests/test_chat_session_reminders.py

------
https://chatgpt.com/codex/tasks/task_e_68e12d4d33e88322a8aad3b2c3fb8c9c