### PR TITLE
Ensure chat history export handles missing directories

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,8 @@
+# Release Notes
+
+## Unreleased
+
+- Chat history exports now automatically create any missing parent directories
+  before writing the export file. This makes it possible to export directly to
+  new, nested folders without preparing them ahead of time.
+

--- a/modules/Chat/chat_session.py
+++ b/modules/Chat/chat_session.py
@@ -199,6 +199,16 @@ class ChatSession:
         export_text = "".join(session_metadata + message_lines)
 
         try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            message = (
+                f"Failed to create directory for chat history export at "
+                f"{target.parent}: {exc}"
+            )
+            self.ATLAS.logger.error(message, exc_info=True)
+            raise ChatHistoryExportError(message) from exc
+
+        try:
             target.write_text(export_text, encoding="utf-8")
         except Exception as exc:
             message = f"Failed to export chat history to {target}: {exc}"

--- a/tests/test_chat_session_export.py
+++ b/tests/test_chat_session_export.py
@@ -74,6 +74,20 @@ class ChatSessionExportTests(unittest.TestCase):
         self.assertIn('    metadata: {"foo": "bar"}', data)
         self.assertIn("3. assistant: Hi there!", data)
 
+    def test_export_history_creates_missing_directories(self):
+        self.session.conversation_history = [
+            {"role": "system", "content": "Persona rules"},
+            {"role": "user", "content": "Hello"},
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            export_path = Path(tmpdir) / "nested" / "exports" / "chat.txt"
+            result = self.session.export_history(export_path)
+
+            self.assertTrue(export_path.exists())
+            self.assertEqual(result.path, export_path)
+            self.assertEqual(result.message_count, 2)
+
     def test_export_history_raises_when_empty(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             export_path = Path(tmpdir) / "empty.txt"


### PR DESCRIPTION
## Summary
- ensure chat history exports create missing parent directories before writing
- add a regression test covering exports into nested directories
- document the new export behavior in the release notes

## Testing
- pytest tests/test_chat_session_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e156f9758883228b975c5e169bb050