### PR TITLE
Handle missing persona prompts in chat sessions

### DIFF
--- a/modules/Chat/chat_session.py
+++ b/modules/Chat/chat_session.py
@@ -113,13 +113,21 @@ class ChatSession:
             thread_name=thread_name or "ChatSessionTask",
         )
 
-    def switch_persona(self, new_persona_prompt: str):
-        self.current_persona_prompt = new_persona_prompt
+    def switch_persona(self, new_persona_prompt: str | None):
+        prompt = new_persona_prompt or None
+        self.current_persona_prompt = prompt
         # Remove any existing system messages
-        self.conversation_history = [msg for msg in self.conversation_history if msg['role'] != 'system']
-        # Insert the new persona's system prompt at the start of the conversation
-        self.conversation_history.insert(0, {"role": "system", "content": new_persona_prompt})
-        self.ATLAS.logger.info(f"Switched to new persona: {new_persona_prompt[:50]}...")  # Log first 50 chars
+        self.conversation_history = [
+            msg for msg in self.conversation_history if msg["role"] != "system"
+        ]
+        if prompt:
+            # Insert the new persona's system prompt at the start of the conversation
+            self.conversation_history.insert(0, {"role": "system", "content": prompt})
+            self.ATLAS.logger.info(
+                f"Switched to new persona: {prompt[:50]}..."
+            )  # Log first 50 chars
+        else:
+            self.ATLAS.logger.info("Cleared persona system prompt; no persona active.")
         self.messages_since_last_reminder = 0
 
     def reinforce_persona(self):

--- a/tests/test_chat_session_persona_switch.py
+++ b/tests/test_chat_session_persona_switch.py
@@ -1,0 +1,39 @@
+import logging
+
+import pytest
+
+from modules.Chat.chat_session import ChatSession
+
+
+class DummyAtlas:
+    def __init__(self):
+        self._default_provider = "dummy-provider"
+        self._default_model = "dummy-model"
+        self.logger = logging.getLogger("ChatSessionPersonaSwitchTests")
+        self.persona_manager = None
+        self.provider_manager = None
+
+    def get_default_provider(self):
+        return self._default_provider
+
+    def get_default_model(self):
+        return self._default_model
+
+    async def maybe_text_to_speech(self, response):  # pragma: no cover - simple stub
+        return None
+
+
+@pytest.mark.parametrize("missing_prompt", ["", None])
+def test_switch_persona_without_prompt_removes_system_messages(missing_prompt):
+    atlas = DummyAtlas()
+    session = ChatSession(atlas)
+
+    # Seed an active persona and a conversation history entry
+    session.switch_persona("Active persona prompt")
+    session.conversation_history.append({"role": "user", "content": "Hello"})
+
+    session.switch_persona(missing_prompt)
+
+    assert session.current_persona_prompt is None
+    assert all(message["role"] != "system" for message in session.conversation_history)
+    assert session.messages_since_last_reminder == 0


### PR DESCRIPTION
## Summary
- update chat session persona switching to clear system messages when the persona prompt is missing
- reset the stored persona prompt when none is provided
- add regression tests covering persona switching with empty or missing prompts

## Testing
- pytest tests/test_chat_session_persona_switch.py

------
https://chatgpt.com/codex/tasks/task_e_68e157d7ace083228da3fcee56f3e286