### PR TITLE
Ensure OpenAI model prioritization retains all results

### DIFF
--- a/ATLAS/provider_manager.py
+++ b/ATLAS/provider_manager.py
@@ -755,7 +755,9 @@ class ProviderManager:
             if any(token in name for token in ("gpt", "omni", "o1", "o3", "chat"))
         ]
         if prioritized:
-            unique_models = prioritized
+            prioritized_set = set(prioritized)
+            trailing = [name for name in unique_models if name not in prioritized_set]
+            unique_models = prioritized + trailing
 
         if unique_models:
             try:

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -1440,11 +1440,16 @@ def test_list_openai_models_fetches_and_prioritizes(provider_manager, monkeypatc
     result = asyncio.run(provider_manager.list_openai_models())
 
     assert result["error"] is None
-    assert result["models"] == ["chat-awesome", "gpt-4o"]
+    assert result["models"] == [
+        "chat-awesome",
+        "gpt-4o",
+        "text-embedding-3-small",
+    ]
     assert result["base_url"].endswith("/v1")
     cached = provider_manager.model_manager.models["OpenAI"]
     assert cached[0] == "gpt-4o"
-    assert "chat-awesome" in cached
+    assert cached[1] == "chat-awesome"
+    assert "text-embedding-3-small" in cached
 
 
 def test_list_openai_models_handles_network_error(provider_manager, monkeypatch):


### PR DESCRIPTION
## Summary
- adjust OpenAI model ranking to keep prioritized chat models first while retaining the full discovered list
- extend provider manager test to confirm mixed model IDs return every model with chat-focused entries first

## Testing
- pytest tests/test_provider_manager.py -k "list_openai_models_fetches_and_prioritizes"


------
https://chatgpt.com/codex/tasks/task_e_68e15c19d84c832290f3fa30890dd724