### PR TITLE
Add conversation IDs to chat sessions

### DIFF
--- a/modules/Chat/chat_session.py
+++ b/modules/Chat/chat_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
@@ -37,7 +38,20 @@ class ChatSession:
         self.current_persona_prompt = None
         self.messages_since_last_reminder = 0
         self.reminder_interval = 10  # Remind of persona every 10 messages
+        self._conversation_id = self._generate_conversation_id()
         self.set_default_provider_and_model()
+
+    def _generate_conversation_id(self) -> str:
+        return uuid.uuid4().hex
+
+    @property
+    def conversation_id(self) -> str:
+        return self._conversation_id
+
+    def get_conversation_id(self) -> str:
+        """Return the current conversation identifier."""
+
+        return self._conversation_id
 
     def set_default_provider_and_model(self):
         self.current_provider = self.ATLAS.get_default_provider()
@@ -144,6 +158,7 @@ class ChatSession:
         self.conversation_history = []
         self.current_persona_prompt = None
         self.messages_since_last_reminder = 0
+        self._conversation_id = self._generate_conversation_id()
         self.set_default_provider_and_model()
 
     def set_model(self, model: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,12 +83,22 @@ if "google" not in sys.modules:
     speech_module.AudioEncoding = types.SimpleNamespace(MP3=1)
     speech_module.SsmlVoiceGender = _DummySsmlVoiceGender()
 
+    texttospeech_module = types.ModuleType("google.cloud.texttospeech")
+    texttospeech_module.VoiceSelectionParams = _DummyVoiceSelectionParams
+    texttospeech_module.TextToSpeechClient = _DummySpeechClient
+    texttospeech_module.SynthesisInput = _DummySynthesisInput
+    texttospeech_module.AudioConfig = _DummyAudioConfig
+    texttospeech_module.AudioEncoding = types.SimpleNamespace(MP3=1)
+    texttospeech_module.SsmlVoiceGender = _DummySsmlVoiceGender()
+
     cloud_module.speech_v1p1beta1 = speech_module
+    cloud_module.texttospeech = texttospeech_module
     google_module.cloud = cloud_module
 
     sys.modules["google"] = google_module
     sys.modules["google.cloud"] = cloud_module
     sys.modules["google.cloud.speech_v1p1beta1"] = speech_module
+    sys.modules["google.cloud.texttospeech"] = texttospeech_module
 
 
 if "sounddevice" not in sys.modules:

--- a/tests/test_atlas_generate_response.py
+++ b/tests/test_atlas_generate_response.py
@@ -1,0 +1,29 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from ATLAS.ATLAS import ATLAS
+
+
+def test_generate_response_returns_with_conversation_id():
+    atlas = ATLAS.__new__(ATLAS)
+    atlas.logger = SimpleNamespace(error=Mock())
+    atlas.current_persona = "Persona"
+
+    provider_generate = AsyncMock(return_value="ok")
+    atlas.provider_manager = SimpleNamespace(generate_response=provider_generate)
+    atlas.chat_session = SimpleNamespace(conversation_id="conversation-123")
+    atlas._ensure_user_identity = Mock(return_value=("user", "User"))
+    atlas.maybe_text_to_speech = AsyncMock()
+
+    messages = [{"role": "user", "content": "Hello"}]
+    result = asyncio.run(atlas.generate_response(messages))
+
+    assert result == "ok"
+    provider_generate.assert_awaited_once()
+    await_args = provider_generate.await_args
+    assert await_args.kwargs["conversation_id"] == "conversation-123"
+    assert await_args.kwargs["messages"] is messages
+    assert await_args.kwargs["current_persona"] == "Persona"
+    atlas.maybe_text_to_speech.assert_awaited_once_with("ok")
+    atlas.logger.error.assert_not_called()

--- a/tests/test_chat_async_helper.py
+++ b/tests/test_chat_async_helper.py
@@ -372,6 +372,7 @@ class _DummyChatSession:
         self.last_error = None
         self.last_thread_name = None
         self.messages = []
+        self._conversation_id = "dummy-session-id"
 
     async def send_message(self, message):  # pragma: no cover - exercised via factory
         self.messages.append(message)
@@ -390,6 +391,10 @@ class _DummyChatSession:
         self.last_error = on_error
         self.last_thread_name = thread_name
         return Future()
+
+    @property
+    def conversation_id(self):
+        return self._conversation_id
 
 
 class _FakeBuffer:

--- a/tests/test_chat_session_persona_switch.py
+++ b/tests/test_chat_session_persona_switch.py
@@ -37,3 +37,14 @@ def test_switch_persona_without_prompt_removes_system_messages(missing_prompt):
     assert session.current_persona_prompt is None
     assert all(message["role"] != "system" for message in session.conversation_history)
     assert session.messages_since_last_reminder == 0
+
+
+def test_reset_conversation_refreshes_conversation_id():
+    atlas = DummyAtlas()
+    session = ChatSession(atlas)
+
+    original_id = session.conversation_id
+    session.reset_conversation()
+
+    assert session.conversation_id
+    assert session.conversation_id != original_id


### PR DESCRIPTION
## Summary
- generate and expose immutable conversation identifiers on chat sessions
- reset the identifier when conversations are cleared and update supporting test doubles
- cover the new behavior with targeted tests and ensure google text-to-speech is stubbed for imports

## Testing
- pytest tests/test_chat_session_persona_switch.py tests/test_chat_async_helper.py tests/test_atlas_generate_response.py

------
https://chatgpt.com/codex/tasks/task_e_68e1680701888322ade5b00688e6d4cb