### PR TITLE
Ensure tool manager reuses active provider manager

### DIFF
--- a/modules/Providers/Mistral/Mistral_gen_response.py
+++ b/modules/Providers/Mistral/Mistral_gen_response.py
@@ -908,20 +908,28 @@ class MistralGenerator:
             function_payload = message.get("function_call")
             if not function_payload:
                 continue
+            provider_manager = None
+            if conversation_manager is not None:
+                atlas = getattr(conversation_manager, "ATLAS", None)
+                if atlas is not None:
+                    provider_manager = getattr(atlas, "provider_manager", None)
+            if provider_manager is None:
+                provider_manager = getattr(self.config_manager, "provider_manager", None)
             tool_response = await use_tool(
-                user,
-                conversation_id,
-                {"function_call": function_payload},
-                conversation_manager,
-                function_map,
-                functions,
-                current_persona,
-                temperature,
-                top_p,
-                frequency_penalty,
-                presence_penalty,
-                conversation_manager,
-                self.config_manager,
+                user=user,
+                conversation_id=conversation_id,
+                message={"function_call": function_payload},
+                conversation_history=conversation_manager,
+                function_map=function_map,
+                functions=functions,
+                current_persona=current_persona,
+                temperature_var=temperature,
+                top_p_var=top_p,
+                frequency_penalty_var=frequency_penalty,
+                presence_penalty_var=presence_penalty,
+                conversation_manager=conversation_manager,
+                provider_manager=provider_manager,
+                config_manager=self.config_manager,
             )
             if tool_response is not None:
                 return tool_response

--- a/modules/Providers/OpenAI/OA_gen_response.py
+++ b/modules/Providers/OpenAI/OA_gen_response.py
@@ -1468,20 +1468,28 @@ class OpenAIGenerator:
             return None
 
         self.logger.info("Handling function call: %s", function_payload)
+        provider_manager = None
+        if conversation_manager is not None:
+            atlas = getattr(conversation_manager, "ATLAS", None)
+            if atlas is not None:
+                provider_manager = getattr(atlas, "provider_manager", None)
+        if provider_manager is None:
+            provider_manager = getattr(self.config_manager, "provider_manager", None)
         tool_response = await use_tool(
-            user,
-            conversation_id,
-            {"function_call": function_payload},
-            conversation_manager,
-            function_map,
-            functions,
-            current_persona,
-            temperature,
-            top_p,
-            frequency_penalty,
-            presence_penalty,
-            conversation_manager,
-            self.config_manager
+            user=user,
+            conversation_id=conversation_id,
+            message={"function_call": function_payload},
+            conversation_history=conversation_manager,
+            function_map=function_map,
+            functions=functions,
+            current_persona=current_persona,
+            temperature_var=temperature,
+            top_p_var=top_p,
+            frequency_penalty_var=frequency_penalty,
+            presence_penalty_var=presence_penalty,
+            conversation_manager=conversation_manager,
+            provider_manager=provider_manager,
+            config_manager=self.config_manager,
         )
 
         if tool_response:

--- a/tests/test_mistral_generator.py
+++ b/tests/test_mistral_generator.py
@@ -703,7 +703,12 @@ def test_mistral_generator_executes_tool_call_from_complete(monkeypatch):
     recorded_messages = []
 
     async def fake_use_tool(*args, **_kwargs):
-        recorded_messages.append(args[2])
+        if "message" in _kwargs:
+            recorded_messages.append(_kwargs["message"])
+        elif len(args) > 2:
+            recorded_messages.append(args[2])
+        else:  # pragma: no cover - defensive fallback
+            recorded_messages.append(None)
         return "tool-result"
 
     monkeypatch.setattr(mistral_module, "use_tool", fake_use_tool)
@@ -759,7 +764,12 @@ def test_mistral_generator_executes_tool_call_from_stream(monkeypatch):
     recorded_messages = []
 
     async def fake_use_tool(*args, **_kwargs):
-        recorded_messages.append(args[2])
+        if "message" in _kwargs:
+            recorded_messages.append(_kwargs["message"])
+        elif len(args) > 2:
+            recorded_messages.append(args[2])
+        else:  # pragma: no cover - defensive fallback
+            recorded_messages.append(None)
         return "stream-tool"
 
     monkeypatch.setattr(mistral_module, "use_tool", fake_use_tool)

--- a/tests/test_openai_generator.py
+++ b/tests/test_openai_generator.py
@@ -137,7 +137,12 @@ def test_responses_tool_call_invokes_tool(monkeypatch):
     recorded = {}
 
     async def fake_use_tool(*args, **kwargs):
-        recorded["message"] = args[2]
+        if "message" in kwargs:
+            recorded["message"] = kwargs["message"]
+        elif len(args) > 2:
+            recorded["message"] = args[2]
+        else:  # pragma: no cover - defensive fallback
+            recorded["message"] = None
         return "tool-output"
 
     monkeypatch.setattr(oa_module, "use_tool", fake_use_tool)
@@ -794,7 +799,12 @@ def test_chat_completion_tool_calls_invokes_tool(monkeypatch):
     recorded = {}
 
     async def fake_use_tool(*args, **kwargs):
-        recorded["message"] = args[2]
+        if "message" in kwargs:
+            recorded["message"] = kwargs["message"]
+        elif len(args) > 2:
+            recorded["message"] = args[2]
+        else:  # pragma: no cover - defensive fallback
+            recorded["message"] = None
         return "tool-response"
 
     monkeypatch.setattr(oa_module, "use_tool", fake_use_tool)

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -131,6 +131,7 @@ def test_use_tool_prefers_supplied_config_manager(monkeypatch):
             frequency_penalty_var=0.0,
             presence_penalty_var=0.0,
             conversation_manager=conversation_history,
+            provider_manager=dummy_config.provider_manager,
             config_manager=dummy_config,
         )
 


### PR DESCRIPTION
## Summary
- add a shared helper in `ToolManager` so tools resolve the live provider manager before calling back into the model
- thread the active provider manager through OpenAI and Mistral tool flows instead of creating fresh config managers
- update supporting tests and stubs to exercise the new keyword API for `use_tool`

## Testing
- pytest tests/test_tool_manager.py
- pytest tests/test_openai_generator.py::test_responses_tool_call_invokes_tool tests/test_mistral_generator.py::test_mistral_generator_executes_tool_call_from_stream


------
https://chatgpt.com/codex/tasks/task_e_68e170fcb8ac8322b3e661491d02f53f