### PR TITLE
Allow injecting shared ModelManager into generators

### DIFF
--- a/ATLAS/provider_manager.py
+++ b/ATLAS/provider_manager.py
@@ -183,12 +183,18 @@ class ProviderManager:
 
     def _ensure_openai_generator(self):
         if self._openai_generator is None:
-            self._openai_generator = get_openai_generator(self.config_manager)
+            self._openai_generator = get_openai_generator(
+                self.config_manager,
+                model_manager=self.model_manager,
+            )
         return self._openai_generator
 
     def _ensure_mistral_generator(self):
         if self._mistral_generator is None:
-            self._mistral_generator = get_mistral_generator(self.config_manager)
+            self._mistral_generator = get_mistral_generator(
+                self.config_manager,
+                model_manager=self.model_manager,
+            )
         return self._mistral_generator
 
     def _ensure_google_generator(self):


### PR DESCRIPTION
## Summary
- allow OpenAI and Mistral generators to accept an optional ModelManager instance and reuse shared caches
- update ProviderManager to pass its cached ModelManager into provider factories
- refresh OpenAI and Mistral generator tests to cover the injectable ModelManager behavior

## Testing
- pytest tests/test_openai_generator.py tests/test_mistral_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68e17a62693883229fb9774b793d9941