### PR TITLE
Fix ONNX session cleanup when unloading models

### DIFF
--- a/modules/Providers/HuggingFace/components/huggingface_model_manager.py
+++ b/modules/Providers/HuggingFace/components/huggingface_model_manager.py
@@ -492,6 +492,8 @@ class HuggingFaceModelManager:
         """
         Unloads the currently loaded model, freeing up resources.
         """
+        previous_model = self.current_model
+
         if self.model:
             del self.model
             del self.tokenizer
@@ -503,13 +505,14 @@ class HuggingFaceModelManager:
             self.model = None
             self.tokenizer = None
             self.pipeline = None
-            self.current_model = None
             self.logger.info("Model unloaded and CUDA cache cleared.")
 
         # Also unload any associated ONNX sessions
-        if self.current_model and self.current_model in self.ort_sessions:
-            del self.ort_sessions[self.current_model]
-            self.logger.info(f"Unloaded ONNX Runtime session for model: {self.current_model}")
+        if previous_model and previous_model in self.ort_sessions:
+            del self.ort_sessions[previous_model]
+            self.logger.info(f"Unloaded ONNX Runtime session for model: {previous_model}")
+
+        self.current_model = None
 
     def get_installed_models(self) -> List[str]:
         """


### PR DESCRIPTION
## Summary
- capture the current model name during unload so cached ONNX sessions are removed reliably
- extend the HuggingFace model manager tests to cover ONNX session cleanup and support environments lacking hub client stubs

## Testing
- pytest tests/test_huggingface_model_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e1822e036c8322a222c15d700bc040