### PR TITLE
Handle optional TTS failures gracefully

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -1200,9 +1200,6 @@ class ATLAS:
         Args:
             response_text: The response payload to vocalize. May be a plain
                 string or a mapping containing ``text``/``audio`` fields.
-
-        Raises:
-            RuntimeError: If text-to-speech is enabled but synthesis fails.
         """
 
         payload_text = ""
@@ -1230,7 +1227,7 @@ class ATLAS:
             await self.speech_manager.text_to_speech(payload_text)
         except Exception as exc:
             self.logger.error("Text-to-speech failed: %s", exc, exc_info=True)
-            raise RuntimeError("Text-to-speech failed") from exc
+            return
 
     def start_stt_listening(self) -> Dict[str, Any]:
         """Begin speech-to-text recording via the active provider.
@@ -1470,7 +1467,12 @@ class ATLAS:
             )
 
             # Perform TTS if enabled
-            await self.maybe_text_to_speech(response)
+            try:
+                await self.maybe_text_to_speech(response)
+            except Exception as tts_exc:
+                self.logger.error(
+                    "Optional text-to-speech failed: %s", tts_exc, exc_info=True
+                )
 
             return response
         except Exception as e:

--- a/tests/test_atlas_generate_response.py
+++ b/tests/test_atlas_generate_response.py
@@ -1,6 +1,18 @@
 import asyncio
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
+
+if "yaml" not in sys.modules:
+    sys.modules["yaml"] = types.SimpleNamespace(safe_load=lambda *args, **kwargs: {})
+
+if "dotenv" not in sys.modules:
+    sys.modules["dotenv"] = types.SimpleNamespace(
+        load_dotenv=lambda *args, **kwargs: None,
+        set_key=lambda *args, **kwargs: None,
+        find_dotenv=lambda *args, **kwargs: "",
+    )
 
 from ATLAS.ATLAS import ATLAS
 
@@ -33,3 +45,33 @@ def test_generate_response_returns_with_conversation_id():
     atlas.maybe_text_to_speech.assert_awaited_once_with("ok")
     atlas.logger.error.assert_not_called()
     provider_manager.set_current_conversation_id.assert_called_with("conversation-123")
+
+
+def test_generate_response_handles_tts_failure():
+    atlas = ATLAS.__new__(ATLAS)
+    atlas.logger = SimpleNamespace(error=Mock(), debug=Mock())
+    atlas.current_persona = "Persona"
+
+    provider_generate = AsyncMock(return_value="ok")
+    provider_manager = SimpleNamespace(
+        generate_response=provider_generate,
+        set_current_conversation_id=Mock(),
+    )
+    atlas.provider_manager = provider_manager
+    atlas.chat_session = SimpleNamespace(conversation_id="conversation-123")
+    atlas._ensure_user_identity = Mock(return_value=("user", "User"))
+
+    atlas.speech_manager = SimpleNamespace(
+        get_tts_status=Mock(return_value=True),
+        text_to_speech=AsyncMock(side_effect=RuntimeError("boom")),
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    result = asyncio.run(atlas.generate_response(messages))
+
+    assert result == "ok"
+    provider_generate.assert_awaited_once()
+    atlas.speech_manager.text_to_speech.assert_awaited_once_with("ok")
+    assert atlas.logger.error.called
+    error_message = atlas.logger.error.call_args[0][0]
+    assert "Text-to-speech failed" in error_message


### PR DESCRIPTION
## Summary
- ensure optional text-to-speech failures are logged and do not raise
- protect generate_response from optional synthesis errors
- expand generate response tests to cover TTS failure handling

## Testing
- pytest tests/test_atlas_generate_response.py

------
https://chatgpt.com/codex/tasks/task_e_68e18522b4fc8322a77d1bce6b8475fc