### PR TITLE
Ensure Grok sampler receives selected model

### DIFF
--- a/modules/Providers/Grok/grok_generate_response.py
+++ b/modules/Providers/Grok/grok_generate_response.py
@@ -58,7 +58,11 @@ class GrokGenerator:
         """
         prompt = self._build_prompt_from_messages(messages)
         self.logger.debug(f"Sending prompt to Grok: {prompt}")
-        result = await self.client.sampler.sample(prompt, max_len=max_tokens)
+        result = await self.client.sampler.sample(
+            prompt,
+            max_len=max_tokens,
+            model=model,
+        )
         response = "".join([token.token_str for token in result])
         self.logger.info(f"Grok response received: {response}")
         return response
@@ -74,7 +78,11 @@ class GrokGenerator:
         """
         prompt = self._build_prompt_from_messages(messages)
         self.logger.debug(f"Streaming prompt to Grok: {prompt}")
-        async for token in self.client.sampler.sample(prompt, max_len=max_tokens):
+        async for token in self.client.sampler.sample(
+            prompt,
+            max_len=max_tokens,
+            model=model,
+        ):
             yield token.token_str
 
     async def process_streaming_response(self, response: AsyncIterator[str]) -> str:


### PR DESCRIPTION
## Summary
- pass the resolved Grok model through to sampler.sample for both streaming and non-streaming paths
- add targeted provider manager tests that confirm the requested model is forwarded to the Grok sampler

## Testing
- pytest tests/test_provider_manager.py::test_grok_generator_passes_model_to_sampler_non_streaming tests/test_provider_manager.py::test_grok_generator_passes_model_to_sampler_streaming -q

------
https://chatgpt.com/codex/tasks/task_e_68e1b5a3d7608322b8cec78503cca23c