### PR TITLE
Run Google TTS synthesis in background thread

### DIFF
--- a/modules/Speech_Services/Google_tts.py
+++ b/modules/Speech_Services/Google_tts.py
@@ -1,6 +1,7 @@
 # modules/Speech_Services/Google/tts.py
 # Description: Text to speech module using Google Cloud Text-to-Speech
 
+import asyncio
 import os
 import re
 import tempfile
@@ -59,10 +60,11 @@ class GoogleTTS(BaseTTS):
         )
 
         try:
-            response = self.client.synthesize_speech(
+            response = await asyncio.to_thread(
+                self.client.synthesize_speech,
                 input=synthesis_input,
                 voice=self.voice,
-                audio_config=audio_config
+                audio_config=audio_config,
             )
             logger.info("Google TTS response received successfully.")
         except Exception as e:


### PR DESCRIPTION
## Summary
- offload Google Cloud Text-to-Speech synthesis to a worker thread so the coroutine stays non-blocking
- extend Google TTS tests to mock the client call and verify asyncio.to_thread is awaited while playback cleanup still occurs

## Testing
- pytest tests/test_speech_manager.py -k "google_tts_text_to_speech" -q

------
https://chatgpt.com/codex/tasks/task_e_68e1bc3e09d88322923b5efe9eb5bf5a