### PR TITLE
Handle .env creation when persisting API keys

### DIFF
--- a/ATLAS/config.py
+++ b/ATLAS/config.py
@@ -199,7 +199,20 @@ class ConfigManager:
 
         env_path = find_dotenv()
         if not env_path:
-            raise FileNotFoundError("`.env` file not found.")
+            app_root = None
+            if isinstance(getattr(self, "env_config", None), Mapping):
+                app_root = self.env_config.get("APP_ROOT")
+            if not app_root:
+                app_root = os.getenv("APP_ROOT")
+            if not app_root:
+                app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+            env_path = os.path.abspath(os.path.join(app_root, ".env"))
+
+            os.makedirs(os.path.dirname(env_path), exist_ok=True)
+            if not os.path.exists(env_path):
+                with open(env_path, "a", encoding="utf-8"):
+                    pass
 
         # Persist the value to the .env file and refresh the loaded environment.
         set_key(env_path, env_key, value or "")


### PR DESCRIPTION
## Summary
- derive the .env path from APP_ROOT when none is discovered and create the file before persisting values
- keep ConfigManager in-memory state synchronized after updating environment-backed credentials
- add a unit test ensuring update_api_key succeeds without a pre-existing .env file and records the new key

## Testing
- pytest tests/test_config_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e26f8056448322848c6761ae5e57f1