### PR TITLE
Handle missing audio files in Google STT

### DIFF
--- a/modules/Speech_Services/Google_stt.py
+++ b/modules/Speech_Services/Google_stt.py
@@ -73,15 +73,19 @@ class GoogleSTT:
         logger.info(f"Transcribing file {audio_file}")
         audio_file_path = os.path.join('assets/user/sst_output', audio_file)
 
-        with open(audio_file_path, 'rb') as audio:
-            audio_content = audio.read()
-
-        audio = speech.RecognitionAudio(content=audio_content)
-        response = self.client.recognize(config=self.config, audio=audio)
-
         if not os.path.exists(audio_file_path):
             logger.error(f"Audio file not found: {audio_file_path}")
             return "No audio file to transcribe"
+
+        try:
+            with open(audio_file_path, 'rb') as audio:
+                audio_content = audio.read()
+        except FileNotFoundError:
+            logger.error(f"Audio file not found: {audio_file_path}")
+            return "No audio file to transcribe"
+
+        audio = speech.RecognitionAudio(content=audio_content)
+        response = self.client.recognize(config=self.config, audio=audio)
 
         transcript = []
         for result in response.results:

--- a/tests/test_speech_manager.py
+++ b/tests/test_speech_manager.py
@@ -787,6 +787,21 @@ def test_google_stt_factory_uses_configured_sample_rate(speech_manager):
     assert google_stt.fs == 22050
 
 
+def test_google_stt_transcribe_returns_friendly_message_for_missing_file():
+    from modules.Speech_Services.Google_stt import GoogleSTT
+
+    google_stt = GoogleSTT()
+    missing_filename = "missing_test_audio_file.wav"
+    missing_path = os.path.join("assets/user/sst_output", missing_filename)
+
+    if os.path.exists(missing_path):
+        os.remove(missing_path)
+
+    result = google_stt.transcribe(missing_filename)
+
+    assert result == "No audio file to transcribe"
+
+
 def test_summary_supports_unregistered_active_service(speech_manager):
     class Voice:
         name = "Fallback"


### PR DESCRIPTION
## Summary
- guard Google STT transcription against missing audio files and keep logging consistent
- add a regression test that exercises the friendly message when the audio file is absent

## Testing
- pytest tests/test_speech_manager.py -k friendly_message

------
https://chatgpt.com/codex/tasks/task_e_68e270c979e48322a3f353f8e33ba6ce