### PR TITLE
Persist default speech provider selection

### DIFF
--- a/modules/Speech_Services/speech_manager.py
+++ b/modules/Speech_Services/speech_manager.py
@@ -1380,11 +1380,16 @@ class SpeechManager:
     def set_default_speech_providers(self, tts_provider: Optional[str] = None, stt_provider: Optional[str] = None):
         """Update the default TTS and/or STT providers in a single call."""
 
+        config_updated = False
+
         if tts_provider:
             if tts_provider in self.get_tts_provider_names():
                 self.set_default_tts_provider(tts_provider)
                 if hasattr(self.config_manager, 'config'):
                     self.config_manager.config['DEFAULT_TTS_PROVIDER'] = tts_provider
+                if hasattr(self.config_manager, 'yaml_config'):
+                    self.config_manager.yaml_config['DEFAULT_TTS_PROVIDER'] = tts_provider
+                config_updated = True
                 logger.info(f"Persisted default TTS provider '{tts_provider}'.")
             else:
                 logger.error(f"Cannot set unknown TTS provider '{tts_provider}'.")
@@ -1394,9 +1399,15 @@ class SpeechManager:
                 self.set_default_stt_provider(stt_provider)
                 if hasattr(self.config_manager, 'config'):
                     self.config_manager.config['DEFAULT_STT_PROVIDER'] = stt_provider
+                if hasattr(self.config_manager, 'yaml_config'):
+                    self.config_manager.yaml_config['DEFAULT_STT_PROVIDER'] = stt_provider
+                config_updated = True
                 logger.info(f"Persisted default STT provider '{stt_provider}'.")
             else:
                 logger.error(f"Cannot set unknown STT provider '{stt_provider}'.")
+
+        if config_updated and hasattr(self.config_manager, '_write_yaml_config'):
+            self.config_manager._write_yaml_config()
 
     def disable_stt(self):
         """Disable speech-to-text by clearing the active provider and state."""

--- a/tests/test_speech_manager.py
+++ b/tests/test_speech_manager.py
@@ -388,12 +388,16 @@ class _DummyConfig:
     def __init__(self):
         self.config = {"OPENAI_API_KEY": "stored-key"}
         self.yaml_config = {}
+        self.yaml_writes = 0
         self._tts_enabled = True
         self.raise_openai_error = False
         self.raise_google_error = False
         self.openai_calls = []
         self.google_credentials = None
         self.google_speech_settings = {}
+
+    def _write_yaml_config(self):
+        self.yaml_writes += 1
 
     def get_tts_enabled(self):
         return self._tts_enabled
@@ -1070,6 +1074,9 @@ def test_set_default_speech_providers_updates_state(speech_manager):
     assert speech_manager.get_default_stt_provider() == "beta"
     assert speech_manager.config_manager.config["DEFAULT_TTS_PROVIDER"] == "alpha"
     assert speech_manager.config_manager.config["DEFAULT_STT_PROVIDER"] == "beta"
+    assert speech_manager.config_manager.yaml_config["DEFAULT_TTS_PROVIDER"] == "alpha"
+    assert speech_manager.config_manager.yaml_config["DEFAULT_STT_PROVIDER"] == "beta"
+    assert speech_manager.config_manager.yaml_writes == 1
 
 
 def test_disable_stt_clears_active_provider(speech_manager):


### PR DESCRIPTION
## Summary
- persist default TTS and STT provider selections to the ConfigManager YAML store
- trigger YAML writes when defaults change so choices survive restarts
- extend speech manager tests to cover YAML persistence of provider changes

## Testing
- pytest tests/test_speech_manager.py::test_set_default_speech_providers_updates_state

------
https://chatgpt.com/codex/tasks/task_e_68e283a8226c832293eb78f887661497