### PR TITLE
Use ConfigManager app root for persona toolboxes

### DIFF
--- a/ATLAS/ToolManager.py
+++ b/ATLAS/ToolManager.py
@@ -57,7 +57,18 @@ def load_function_map_from_current_persona(current_persona, *, refresh=False):
         return None
 
     persona_name = current_persona["name"]
-    maps_path = f'modules/Personas/{persona_name}/Toolbox/maps.py'
+    try:
+        app_root = ConfigManager().get_app_root()
+    except Exception as exc:
+        logger.error(
+            "Unable to determine application root when loading persona '%s': %s",
+            persona_name,
+            exc,
+        )
+        return None
+
+    toolbox_root = os.path.join(app_root, "modules", "Personas", persona_name, "Toolbox")
+    maps_path = os.path.join(toolbox_root, "maps.py")
     module_name = f'persona_{persona_name}_maps'
 
     try:
@@ -128,7 +139,18 @@ def load_functions_from_json(current_persona, *, refresh=False):
         return None
 
     persona_name = current_persona["name"]
-    functions_json_path = f'modules/Personas/{persona_name}/Toolbox/functions.json'
+    try:
+        app_root = ConfigManager().get_app_root()
+    except Exception as exc:
+        logger.error(
+            "Unable to determine application root when loading persona '%s': %s",
+            persona_name,
+            exc,
+        )
+        return None
+
+    toolbox_root = os.path.join(app_root, "modules", "Personas", persona_name, "Toolbox")
+    functions_json_path = os.path.join(toolbox_root, "functions.json")
 
     try:
         file_mtime = os.path.getmtime(functions_json_path)

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 import json
+import os
 import sys
 import types
 from pathlib import Path
@@ -168,6 +169,11 @@ def test_load_function_map_caches_by_persona(monkeypatch):
     )
 
     tool_manager = importlib.import_module("ATLAS.ToolManager")
+    monkeypatch.setattr(
+        tool_manager.ConfigManager,
+        "get_app_root",
+        lambda self: os.fspath(Path.cwd()),
+    )
     monkeypatch.setitem(tool_manager.__dict__, "_function_map_cache", {})
     sys.modules.pop(module_name, None)
 

--- a/tests/test_tool_manager_cache.py
+++ b/tests/test_tool_manager_cache.py
@@ -25,7 +25,7 @@ import ATLAS.ToolManager as tool_manager
 
 
 @pytest.fixture
-def _persona_workspace():
+def _persona_workspace(monkeypatch):
     persona_name = f"CachePersona_{uuid.uuid4().hex}"
     base_dir = Path("modules") / "Personas" / persona_name / "Toolbox"
     base_dir.mkdir(parents=True, exist_ok=True)
@@ -41,6 +41,12 @@ def _persona_workspace():
     )
 
     module_name = f"persona_{persona_name}_maps"
+
+    monkeypatch.setattr(
+        tool_manager.ConfigManager,
+        "get_app_root",
+        lambda self: os.fspath(Path.cwd()),
+    )
 
     try:
         yield {


### PR DESCRIPTION
## Summary
- resolve persona toolbox file paths from the configured application root rather than relative strings
- update ToolManager tests to patch the ConfigManager app root accessor to match the new behavior

## Testing
- pytest tests/test_tool_manager.py tests/test_tool_manager_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68e28adf508483229e68e17ac81a0216