### PR TITLE
Refine user account DB storage and migration

### DIFF
--- a/modules/user_accounts/user_account_db.py
+++ b/modules/user_accounts/user_account_db.py
@@ -2,31 +2,107 @@
 import hashlib
 import hmac
 import os
+import shutil
 import sqlite3
+from pathlib import Path
+from typing import Optional
+
+try:
+    from platformdirs import user_data_dir as _user_data_dir
+except ImportError:  # pragma: no cover - optional dependency
+    try:
+        from appdirs import user_data_dir as _user_data_dir  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        _user_data_dir = None
+
 from ATLAS.config import ConfigManager
 from modules.logging.logger import setup_logger
 
 
+LEGACY_USER_PROFILES_DIR = Path(__file__).resolve().parent / 'user_profiles'
+
+
 class UserAccountDatabase:
-    def __init__(self, db_name="User.db", base_dir=None):
-        self.config_manager = ConfigManager
+    def __init__(self, db_name: str = "User.db", base_dir: Optional[str] = None):
         self.logger = setup_logger(__name__)
+        self.config_manager = ConfigManager()
 
-        if base_dir is not None:
-            root_dir = os.path.abspath(base_dir)
-        else:
-            root_dir = os.path.dirname(os.path.abspath(__file__))
-        user_profiles_dir = os.path.join(root_dir, 'user_profiles')
+        base_directory = self._determine_base_directory(base_dir)
+        self.user_profiles_dir = base_directory / 'user_profiles'
+        self.user_profiles_dir.mkdir(parents=True, exist_ok=True)
 
-        if not os.path.exists(user_profiles_dir):
-            os.makedirs(user_profiles_dir)
+        self.db_path = self.user_profiles_dir / db_name
+        self._migrate_legacy_database(db_name)
 
-        db_path = os.path.join(user_profiles_dir, db_name)
-
-        self.conn = sqlite3.connect(db_path, check_same_thread=False)
+        self.conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
         self.cursor = self.conn.cursor()
 
         self.create_table()
+
+    def _determine_base_directory(self, override_dir: Optional[str]) -> Path:
+        if override_dir is not None:
+            self.logger.debug("Using provided base directory for user accounts: %s", override_dir)
+            return Path(override_dir).expanduser().resolve()
+
+        app_root = self._get_app_root()
+        if app_root:
+            resolved = (Path(app_root).expanduser().resolve() / 'modules' / 'user_accounts')
+            self.logger.debug("Using app root directory for user accounts: %s", resolved)
+            return resolved
+
+        if _user_data_dir:
+            fallback_base = Path(_user_data_dir("ATLAS", "ATLAS"))
+            self.logger.debug("Using OS user data directory for user accounts: %s", fallback_base)
+        else:  # pragma: no cover - only used when no helper available
+            fallback_base = Path.home() / '.atlas'
+            self.logger.debug("Falling back to home directory for user accounts: %s", fallback_base)
+
+        return fallback_base
+
+    def _get_app_root(self) -> Optional[str]:
+        get_app_root = getattr(self.config_manager, 'get_app_root', None)
+        if not callable(get_app_root):
+            return None
+
+        try:
+            return get_app_root()
+        except Exception as exc:  # pragma: no cover - defensive programming
+            self.logger.warning("Failed to retrieve app root from ConfigManager: %s", exc)
+            return None
+
+    def _migrate_legacy_database(self, db_name: str) -> None:
+        legacy_db_path = LEGACY_USER_PROFILES_DIR / db_name
+
+        try:
+            if not legacy_db_path.exists():
+                return
+
+            new_db_path = self.user_profiles_dir / db_name
+            if legacy_db_path.resolve() == new_db_path.resolve():
+                return
+
+            if new_db_path.exists():
+                self.logger.info(
+                    "Legacy database found at %s but new database already exists at %s; skipping migration.",
+                    legacy_db_path,
+                    new_db_path,
+                )
+                return
+
+            new_db_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(legacy_db_path), str(new_db_path))
+            self.logger.info(
+                "Migrated user account database from legacy location %s to %s.",
+                legacy_db_path,
+                new_db_path,
+            )
+        except OSError as exc:
+            self.logger.error(
+                "Failed to migrate legacy user account database from %s: %s",
+                legacy_db_path,
+                exc,
+            )
+            raise
 
     def create_table(self):
         query = """

--- a/tests/test_user_account_db.py
+++ b/tests/test_user_account_db.py
@@ -1,5 +1,7 @@
+import sqlite3
 import sys
 import types
+from pathlib import Path
 
 if 'yaml' not in sys.modules:
     yaml_stub = types.ModuleType('yaml')
@@ -18,22 +20,35 @@ from modules.user_accounts import user_account_db
 
 
 class _StubLogger:
+    def __init__(self):
+        self.infos = []
+
     def info(self, *args, **kwargs):
-        pass
+        self.infos.append((args, kwargs))
 
     def debug(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
         pass
 
     def error(self, *args, **kwargs):
         pass
 
 
-class _StubConfigManager(types.SimpleNamespace):
-    pass
+def _install_config_manager_stub(monkeypatch, app_root=None):
+    class _StubConfigManager:
+        def __init__(self):
+            self._app_root = app_root
+
+        def get_app_root(self):
+            return self._app_root
+
+    monkeypatch.setattr(user_account_db, 'ConfigManager', _StubConfigManager)
 
 
 def _create_db(tmp_path, monkeypatch):
-    monkeypatch.setattr(user_account_db, 'ConfigManager', _StubConfigManager)
+    _install_config_manager_stub(monkeypatch)
     monkeypatch.setattr(user_account_db, 'setup_logger', lambda *_args, **_kwargs: _StubLogger())
 
     return user_account_db.UserAccountDatabase(db_name='test_users.db', base_dir=str(tmp_path))
@@ -89,5 +104,50 @@ def test_verify_user_password_uses_hash_check(tmp_path, monkeypatch):
         assert verify_calls == [(hashed_value, 'initial')]
         assert not db.verify_user_password('bob', 'wrong')
         assert not db.verify_user_password('unknown', 'initial')
+    finally:
+        db.close_connection()
+
+
+def test_database_uses_app_root_directory(tmp_path, monkeypatch):
+    app_root = tmp_path / 'app-root'
+    _install_config_manager_stub(monkeypatch, str(app_root))
+
+    logger = _StubLogger()
+    monkeypatch.setattr(user_account_db, 'setup_logger', lambda *_args, **_kwargs: logger)
+
+    db = user_account_db.UserAccountDatabase(db_name='app_root.db')
+
+    try:
+        expected_dir = app_root / 'modules' / 'user_accounts' / 'user_profiles'
+        assert db.user_profiles_dir == expected_dir
+        assert db.db_path == expected_dir / 'app_root.db'
+        assert db.db_path.exists()
+    finally:
+        db.close_connection()
+
+
+def test_database_migrates_from_legacy_location(tmp_path, monkeypatch):
+    app_root = tmp_path / 'new-root'
+    _install_config_manager_stub(monkeypatch, str(app_root))
+
+    logger = _StubLogger()
+    monkeypatch.setattr(user_account_db, 'setup_logger', lambda *_args, **_kwargs: logger)
+
+    legacy_dir = tmp_path / 'legacy'
+    legacy_dir.mkdir()
+    monkeypatch.setattr(user_account_db, 'LEGACY_USER_PROFILES_DIR', legacy_dir)
+
+    legacy_db_path = legacy_dir / 'legacy.db'
+    sqlite3.connect(str(legacy_db_path)).close()
+
+    db = user_account_db.UserAccountDatabase(db_name='legacy.db')
+
+    try:
+        expected_new_path = app_root / 'modules' / 'user_accounts' / 'user_profiles' / 'legacy.db'
+        assert db.db_path == expected_new_path
+        assert db.db_path.exists()
+        assert not legacy_db_path.exists()
+
+        assert any('Migrated user account database' in args[0] for args, _ in logger.infos)
     finally:
         db.close_connection()


### PR DESCRIPTION
## Summary
- derive the user account database directory from the configured app root or a user-data fallback
- migrate any legacy database file into the new location with informative logging
- extend the user account database tests to cover the new directory selection and migration behavior

## Testing
- pytest tests/test_user_account_db.py

------
https://chatgpt.com/codex/tasks/task_e_68e292dd8d4c8322bf7cdaff73032606