### PR TITLE
Reuse cached ConfigManager when loading persona tool data

### DIFF
--- a/ATLAS/ToolManager.py
+++ b/ATLAS/ToolManager.py
@@ -15,6 +15,21 @@ logger = setup_logger(__name__)
 
 _function_map_cache = {}
 _function_payload_cache = {}
+_default_config_manager = None
+
+
+def _get_config_manager(candidate=None):
+    """Return a :class:`ConfigManager`, caching the default instance."""
+
+    global _default_config_manager
+
+    if candidate is not None:
+        return candidate
+
+    if _default_config_manager is None:
+        _default_config_manager = ConfigManager()
+
+    return _default_config_manager
 
 
 def _resolve_provider_manager(provider_manager=None, config_manager=None):
@@ -50,7 +65,12 @@ def get_required_args(function):
         if param.default == param.empty and param.name != 'self'
     ]
 
-def load_function_map_from_current_persona(current_persona, *, refresh=False):
+def load_function_map_from_current_persona(
+    current_persona,
+    *,
+    refresh=False,
+    config_manager=None,
+):
     logger.info("Attempting to load function map from current persona.")
     if not current_persona or "name" not in current_persona:
         logger.error("Current persona is None or does not have a 'name' key.")
@@ -58,7 +78,7 @@ def load_function_map_from_current_persona(current_persona, *, refresh=False):
 
     persona_name = current_persona["name"]
     try:
-        app_root = ConfigManager().get_app_root()
+        app_root = _get_config_manager(config_manager).get_app_root()
     except Exception as exc:
         logger.error(
             "Unable to determine application root when loading persona '%s': %s",
@@ -132,7 +152,12 @@ def load_function_map_from_current_persona(current_persona, *, refresh=False):
         logger.error(f"Error loading function map for persona '{persona_name}': {e}", exc_info=True)
     return None
 
-def load_functions_from_json(current_persona, *, refresh=False):
+def load_functions_from_json(
+    current_persona,
+    *,
+    refresh=False,
+    config_manager=None,
+):
     logger.info("Attempting to load functions from JSON for the current persona.")
     if not current_persona or "name" not in current_persona:
         logger.error("Current persona is None or does not have a 'name' key.")
@@ -140,7 +165,7 @@ def load_functions_from_json(current_persona, *, refresh=False):
 
     persona_name = current_persona["name"]
     try:
-        app_root = ConfigManager().get_app_root()
+        app_root = _get_config_manager(config_manager).get_app_root()
     except Exception as exc:
         logger.error(
             "Unable to determine application root when loading persona '%s': %s",

--- a/modules/Providers/Google/GG_gen_response.py
+++ b/modules/Providers/Google/GG_gen_response.py
@@ -464,7 +464,10 @@ class GoogleGeminiGenerator:
 
         provided_functions = functions
         if provided_functions is None and current_persona:
-            provided_functions = load_functions_from_json(current_persona)
+            provided_functions = load_functions_from_json(
+                current_persona,
+                config_manager=self.config_manager,
+            )
 
         if isinstance(provided_functions, dict):
             provided_functions = provided_functions.get("functions") or provided_functions.get(
@@ -479,7 +482,10 @@ class GoogleGeminiGenerator:
                     seen_names.add(declaration.name)
 
         function_map = (
-            load_function_map_from_current_persona(current_persona)
+            load_function_map_from_current_persona(
+                current_persona,
+                config_manager=self.config_manager,
+            )
             if current_persona
             else None
         )

--- a/modules/Providers/Mistral/Mistral_gen_response.py
+++ b/modules/Providers/Mistral/Mistral_gen_response.py
@@ -309,7 +309,10 @@ class MistralGenerator:
                     provided_functions = functions
                     if provided_functions is None and current_persona is not None:
                         try:
-                            provided_functions = load_functions_from_json(current_persona)
+                            provided_functions = load_functions_from_json(
+                                current_persona,
+                                config_manager=self.config_manager,
+                            )
                         except Exception as exc:  # pragma: no cover - defensive logging
                             self.logger.warning(
                                 "Failed to load functions from persona for Mistral: %s",
@@ -321,7 +324,10 @@ class MistralGenerator:
                     function_map = None
                     if current_persona is not None:
                         try:
-                            function_map = load_function_map_from_current_persona(current_persona)
+                            function_map = load_function_map_from_current_persona(
+                                current_persona,
+                                config_manager=self.config_manager,
+                            )
                         except Exception as exc:  # pragma: no cover - defensive logging
                             self.logger.warning(
                                 "Failed to load function map for Mistral persona: %s",

--- a/modules/Providers/OpenAI/OA_gen_response.py
+++ b/modules/Providers/OpenAI/OA_gen_response.py
@@ -191,7 +191,10 @@ class OpenAIGenerator:
             # Load functions if not provided
             if functions is None and current_persona:
                 self.logger.info("No functions provided; attempting to load from current persona.")
-                functions = load_functions_from_json(current_persona)
+                functions = load_functions_from_json(
+                    current_persona,
+                    config_manager=self.config_manager,
+                )
                 if functions:
                     self.logger.info(f"Functions loaded from JSON: {functions}")
                 else:
@@ -202,7 +205,14 @@ class OpenAIGenerator:
                 self.logger.warning("No functions to load or provide.")
 
             # Load function map
-            function_map = load_function_map_from_current_persona(current_persona) if current_persona else None
+            function_map = (
+                load_function_map_from_current_persona(
+                    current_persona,
+                    config_manager=self.config_manager,
+                )
+                if current_persona
+                else None
+            )
             if function_map:
                 self.logger.info(f"Function map loaded: {function_map}")
             else:


### PR DESCRIPTION
## Summary
- add a cached ConfigManager helper so persona tool loaders reuse an existing instance when none is supplied
- thread the active ConfigManager through OpenAI, Mistral, and Google generators when loading persona tools
- extend ToolManager cache tests to verify only a single ConfigManager instantiation occurs across repeated loads

## Testing
- pytest tests/test_tool_manager_cache.py
- pytest tests/test_tool_manager.py
- pytest tests/test_mistral_generator.py tests/test_atlas_status.py

------
https://chatgpt.com/codex/tasks/task_e_68e296e9bda88322a99b5d29a5467633