### PR TITLE
Add GTK account management dialog and active user signaling

### DIFF
--- a/ATLAS/persona_manager.py
+++ b/ATLAS/persona_manager.py
@@ -103,6 +103,25 @@ class PersonaManager:
             self.logger.error(f"JSON file for persona '{persona_name}' not found at '{json_file}'.")
             return None
 
+    def set_user(self, user: str) -> None:
+        """Update personalization state for a new active user."""
+
+        sanitized = (user or "User").strip() or "User"
+        if sanitized == self.user:
+            return
+
+        self.user = sanitized
+        self.user_data_manager = UserDataManager(self.user)
+
+        if self.current_persona is not None:
+            try:
+                self.current_system_prompt = self.build_system_prompt(self.current_persona)
+            except Exception:  # pragma: no cover - defensive logging only
+                self.logger.error(
+                    "Failed to rebuild system prompt for persona '%s'", self.current_persona.get("name"),
+                    exc_info=True,
+                )
+
 
     def get_persona(self, persona_name: str) -> Optional[dict]:
         """Retrieve the persona by name, loading it from disk if necessary."""

--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -1,0 +1,416 @@
+"""Dialog for managing ATLAS user accounts."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import GLib, Gtk
+
+from GTKUI.Utils.utils import apply_css, create_box
+
+
+class AccountDialog(Gtk.Window):
+    """Provide login, registration, and logout flows for ATLAS accounts."""
+
+    def __init__(self, atlas, parent: Optional[Gtk.Window] = None) -> None:
+        super().__init__(title="Account Management")
+        self.logger = logging.getLogger(__name__)
+        self.ATLAS = atlas
+        self._active_user_listener = None
+        self._active_username: Optional[str] = None
+        self._active_display_name: Optional[str] = None
+
+        self.set_modal(True)
+        if parent is not None:
+            try:
+                self.set_transient_for(parent)
+            except Exception:  # pragma: no cover - defensive for stub environments
+                pass
+
+        self.set_default_size(420, 420)
+
+        apply_css()
+        context = self.get_style_context()
+        context.add_class("chat-page")
+        context.add_class("sidebar")
+
+        self._build_ui()
+        self._subscribe_to_active_user()
+        self.connect("close-request", self._on_close_request)
+
+    # ------------------------------------------------------------------
+    # UI construction helpers
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        container = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=12, margin=18)
+        self.set_child(container)
+
+        self.status_label = Gtk.Label()
+        self.status_label.set_xalign(0.0)
+        container.append(self.status_label)
+
+        toggle_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        container.append(toggle_box)
+
+        self.login_toggle_button = Gtk.Button(label="Sign in")
+        self.login_toggle_button.connect("clicked", lambda *_: self._show_form("login"))
+        toggle_box.append(self.login_toggle_button)
+
+        self.register_toggle_button = Gtk.Button(label="Create account")
+        self.register_toggle_button.connect("clicked", lambda *_: self._show_form("register"))
+        toggle_box.append(self.register_toggle_button)
+
+        self.login_box = self._build_login_form()
+        container.append(self.login_box)
+
+        self.register_box = self._build_registration_form()
+        self._set_widget_visible(self.register_box, False)
+        container.append(self.register_box)
+
+        self.logout_button = Gtk.Button(label="Log out")
+        self.logout_button.connect("clicked", self._on_logout_clicked)
+        container.append(self.logout_button)
+
+        self._forms = {
+            "login": self.login_box,
+            "register": self.register_box,
+        }
+        self._active_form = "login"
+        self._update_toggle_buttons()
+
+    def _build_login_form(self) -> Gtk.Widget:
+        wrapper = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=10, margin=0)
+
+        grid = Gtk.Grid(column_spacing=8, row_spacing=8)
+        wrapper.append(grid)
+
+        username_label = Gtk.Label(label="Username")
+        username_label.set_xalign(0.0)
+        grid.attach(username_label, 0, 0, 1, 1)
+
+        self.login_username_entry = Gtk.Entry()
+        self.login_username_entry.set_placeholder_text("Your username")
+        grid.attach(self.login_username_entry, 1, 0, 1, 1)
+
+        password_label = Gtk.Label(label="Password")
+        password_label.set_xalign(0.0)
+        grid.attach(password_label, 0, 1, 1, 1)
+
+        self.login_password_entry = Gtk.Entry()
+        self.login_password_entry.set_visibility(False)
+        self.login_password_entry.set_invisible_char("•")
+        self.login_password_entry.set_placeholder_text("Your password")
+        grid.attach(self.login_password_entry, 1, 1, 1, 1)
+
+        self.login_feedback_label = Gtk.Label()
+        self.login_feedback_label.set_xalign(0.0)
+        wrapper.append(self.login_feedback_label)
+
+        self.login_button = Gtk.Button(label="Sign in")
+        self.login_button.connect("clicked", self._on_login_clicked)
+        wrapper.append(self.login_button)
+
+        return wrapper
+
+    def _build_registration_form(self) -> Gtk.Widget:
+        wrapper = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=10, margin=0)
+
+        grid = Gtk.Grid(column_spacing=8, row_spacing=8)
+        wrapper.append(grid)
+
+        username_label = Gtk.Label(label="Username")
+        username_label.set_xalign(0.0)
+        grid.attach(username_label, 0, 0, 1, 1)
+
+        self.register_username_entry = Gtk.Entry()
+        self.register_username_entry.set_placeholder_text("Choose a username")
+        grid.attach(self.register_username_entry, 1, 0, 1, 1)
+
+        email_label = Gtk.Label(label="Email")
+        email_label.set_xalign(0.0)
+        grid.attach(email_label, 0, 1, 1, 1)
+
+        self.register_email_entry = Gtk.Entry()
+        self.register_email_entry.set_placeholder_text("name@example.com")
+        grid.attach(self.register_email_entry, 1, 1, 1, 1)
+
+        password_label = Gtk.Label(label="Password")
+        password_label.set_xalign(0.0)
+        grid.attach(password_label, 0, 2, 1, 1)
+
+        self.register_password_entry = Gtk.Entry()
+        self.register_password_entry.set_visibility(False)
+        self.register_password_entry.set_invisible_char("•")
+        self.register_password_entry.set_placeholder_text("Create a password")
+        grid.attach(self.register_password_entry, 1, 2, 1, 1)
+
+        confirm_label = Gtk.Label(label="Confirm password")
+        confirm_label.set_xalign(0.0)
+        grid.attach(confirm_label, 0, 3, 1, 1)
+
+        self.register_confirm_entry = Gtk.Entry()
+        self.register_confirm_entry.set_visibility(False)
+        self.register_confirm_entry.set_invisible_char("•")
+        self.register_confirm_entry.set_placeholder_text("Repeat password")
+        grid.attach(self.register_confirm_entry, 1, 3, 1, 1)
+
+        name_label = Gtk.Label(label="Display name (optional)")
+        name_label.set_xalign(0.0)
+        grid.attach(name_label, 0, 4, 1, 1)
+
+        self.register_name_entry = Gtk.Entry()
+        self.register_name_entry.set_placeholder_text("How should we greet you?")
+        grid.attach(self.register_name_entry, 1, 4, 1, 1)
+
+        dob_label = Gtk.Label(label="Date of birth (optional)")
+        dob_label.set_xalign(0.0)
+        grid.attach(dob_label, 0, 5, 1, 1)
+
+        self.register_dob_entry = Gtk.Entry()
+        self.register_dob_entry.set_placeholder_text("YYYY-MM-DD")
+        grid.attach(self.register_dob_entry, 1, 5, 1, 1)
+
+        self.register_feedback_label = Gtk.Label()
+        self.register_feedback_label.set_xalign(0.0)
+        wrapper.append(self.register_feedback_label)
+
+        self.register_button = Gtk.Button(label="Create account")
+        self.register_button.connect("clicked", self._on_register_clicked)
+        wrapper.append(self.register_button)
+
+        return wrapper
+
+    # ------------------------------------------------------------------
+    # Active user synchronisation
+    # ------------------------------------------------------------------
+    def _subscribe_to_active_user(self) -> None:
+        def _listener(username: str, display_name: str) -> None:
+            GLib.idle_add(self._apply_active_user_state, username, display_name)
+
+        try:
+            self._active_user_listener = _listener
+            self.ATLAS.add_active_user_change_listener(_listener)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.logger.error("Unable to subscribe to active user changes: %s", exc, exc_info=True)
+            self._active_user_listener = None
+
+    def _apply_active_user_state(self, username: str, display_name: str) -> bool:
+        self._active_username = username
+        self._active_display_name = display_name
+
+        persisted = None
+        try:
+            persisted = self.ATLAS.config_manager.get_active_user()
+        except Exception:  # pragma: no cover - config lookups are best-effort
+            persisted = None
+
+        if persisted:
+            message = f"Signed in as {display_name}"
+        else:
+            message = "No active account"
+
+        self.status_label.set_text(message)
+        try:
+            self.logout_button.set_sensitive(bool(persisted))
+        except Exception:  # pragma: no cover - stub safety
+            pass
+
+        return False
+
+    # ------------------------------------------------------------------
+    # Toggle helpers
+    # ------------------------------------------------------------------
+    def _show_form(self, name: str) -> None:
+        if name == self._active_form:
+            return
+
+        for form_name, widget in self._forms.items():
+            should_show = form_name == name
+            if not self._set_widget_visible(widget, should_show):
+                if should_show:
+                    getattr(widget, "show", lambda: None)()
+                else:
+                    getattr(widget, "hide", lambda: None)()
+
+        self._active_form = name
+        self._update_toggle_buttons()
+
+    def _update_toggle_buttons(self) -> None:
+        if self._active_form == "login":
+            self.login_toggle_button.add_css_class("suggested-action")
+            self.register_toggle_button.remove_css_class("suggested-action")
+        else:
+            self.register_toggle_button.add_css_class("suggested-action")
+            self.login_toggle_button.remove_css_class("suggested-action")
+
+    # ------------------------------------------------------------------
+    # Login flow
+    # ------------------------------------------------------------------
+    def _set_login_busy(self, busy: bool, message: Optional[str] = None) -> None:
+        self.login_button.set_sensitive(not busy)
+        if message is not None:
+            self.login_feedback_label.set_text(message)
+
+    def _on_login_clicked(self, _button) -> None:
+        username = (self.login_username_entry.get_text() or "").strip()
+        password = self.login_password_entry.get_text() or ""
+
+        if not username or not password:
+            self.login_feedback_label.set_text("Username and password are required.")
+            return
+
+        self._set_login_busy(True, "Signing in…")
+
+        def factory():
+            return self.ATLAS.login_user_account(username, password)
+
+        def on_success(result: bool) -> None:
+            GLib.idle_add(self._handle_login_result, bool(result))
+
+        def on_error(exc: Exception) -> None:
+            GLib.idle_add(self._handle_login_error, exc)
+
+        try:
+            self.ATLAS.run_in_background(
+                factory,
+                on_success=on_success,
+                on_error=on_error,
+                thread_name="user-login",
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.logger.error("Failed to start login task: %s", exc, exc_info=True)
+            self._handle_login_error(exc)
+
+    def _handle_login_result(self, success: bool) -> bool:
+        self._set_login_busy(False)
+        if success:
+            self.login_feedback_label.set_text("Signed in successfully.")
+            self.close()
+        else:
+            self.login_feedback_label.set_text("Invalid username or password.")
+        return False
+
+    def _handle_login_error(self, exc: Exception) -> bool:
+        self._set_login_busy(False)
+        self.login_feedback_label.set_text(f"Login failed: {exc}")
+        return False
+
+    # ------------------------------------------------------------------
+    # Registration flow
+    # ------------------------------------------------------------------
+    def _set_register_busy(self, busy: bool, message: Optional[str] = None) -> None:
+        self.register_button.set_sensitive(not busy)
+        if message is not None:
+            self.register_feedback_label.set_text(message)
+
+    def _on_register_clicked(self, _button) -> None:
+        username = (self.register_username_entry.get_text() or "").strip()
+        email = (self.register_email_entry.get_text() or "").strip()
+        password = self.register_password_entry.get_text() or ""
+        confirm = self.register_confirm_entry.get_text() or ""
+        name = (self.register_name_entry.get_text() or "").strip() or None
+        dob = (self.register_dob_entry.get_text() or "").strip() or None
+
+        if not username or not email or not password:
+            self.register_feedback_label.set_text("Username, email, and password are required.")
+            return
+
+        if password != confirm:
+            self.register_feedback_label.set_text("Passwords do not match.")
+            return
+
+        self._set_register_busy(True, "Creating account…")
+
+        def factory():
+            return self.ATLAS.register_user_account(username, password, email, name, dob)
+
+        def on_success(result: dict) -> None:
+            GLib.idle_add(self._handle_register_result, result)
+
+        def on_error(exc: Exception) -> None:
+            GLib.idle_add(self._handle_register_error, exc)
+
+        try:
+            self.ATLAS.run_in_background(
+                factory,
+                on_success=on_success,
+                on_error=on_error,
+                thread_name="user-register",
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.logger.error("Failed to start registration task: %s", exc, exc_info=True)
+            self._handle_register_error(exc)
+
+    def _handle_register_result(self, result: dict) -> bool:
+        self._set_register_busy(False)
+        username = result.get("username") if isinstance(result, dict) else None
+        self.register_feedback_label.set_text(
+            f"Account created for {username or 'new user'}." if username else "Account created successfully."
+        )
+        self.close()
+        return False
+
+    def _handle_register_error(self, exc: Exception) -> bool:
+        self._set_register_busy(False)
+        self.register_feedback_label.set_text(f"Registration failed: {exc}")
+        return False
+
+    # ------------------------------------------------------------------
+    # Logout flow
+    # ------------------------------------------------------------------
+    def _on_logout_clicked(self, _button) -> None:
+        self.logout_button.set_sensitive(False)
+        self.status_label.set_text("Signing out…")
+
+        def factory():
+            return self.ATLAS.logout_active_user()
+
+        def on_success(_result) -> None:
+            GLib.idle_add(self._handle_logout_complete)
+
+        def on_error(exc: Exception) -> None:
+            GLib.idle_add(self._handle_logout_error, exc)
+
+        try:
+            self.ATLAS.run_in_background(
+                factory,
+                on_success=on_success,
+                on_error=on_error,
+                thread_name="user-logout",
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.logger.error("Failed to start logout task: %s", exc, exc_info=True)
+            self._handle_logout_error(exc)
+
+    def _handle_logout_complete(self) -> bool:
+        self.status_label.set_text("Signed out.")
+        return False
+
+    def _handle_logout_error(self, exc: Exception) -> bool:
+        self.status_label.set_text(f"Logout failed: {exc}")
+        self.logout_button.set_sensitive(True)
+        return False
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+    def _on_close_request(self, *_args) -> bool:
+        if self._active_user_listener is not None:
+            try:
+                self.ATLAS.remove_active_user_change_listener(self._active_user_listener)
+            except Exception:  # pragma: no cover - defensive logging
+                self.logger.debug("Failed to remove active user listener", exc_info=True)
+            self._active_user_listener = None
+        return False
+
+    @staticmethod
+    def _set_widget_visible(widget, visible: bool) -> bool:
+        setter = getattr(widget, "set_visible", None)
+        if callable(setter):
+            setter(bool(visible))
+            return True
+        return False

--- a/GTKUI/sidebar.py
+++ b/GTKUI/sidebar.py
@@ -21,6 +21,7 @@ import logging
 from GTKUI.Chat.chat_page import ChatPage
 from GTKUI.Persona_manager.persona_management import PersonaManagement
 from GTKUI.Provider_manager.provider_management import ProviderManagement
+from GTKUI.UserAccounts.account_dialog import AccountDialog
 from GTKUI.Utils.utils import apply_css, create_box
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ class Sidebar(Gtk.Window):
         self.persona_management = PersonaManagement(self.ATLAS, self)
         self.provider_management = ProviderManagement(self.ATLAS, self)
         self._chat_page = None
+        self._account_dialog = None
 
         # Set default window size and style.
         self.set_default_size(80, 600)
@@ -53,6 +55,7 @@ class Sidebar(Gtk.Window):
         self.create_icon("Icons/providers.png", self.show_provider_menu, 42, tooltip="Providers")
         self.create_icon("Icons/history.png", self.handle_history_button, 42, tooltip="History")
         self.create_icon("Icons/chat.png", self.show_chat_page, 42, tooltip="Chat")
+        self.create_icon("Icons/user.png", self.show_account_dialog, 42, tooltip="Accounts")
         # Speech settings icon.
         self.create_icon("Icons/speech.png", self.show_speech_settings, 42, tooltip="Speech Settings")
         self.create_icon("Icons/agent.png", self.show_persona_menu, 42, tooltip="Personas")
@@ -155,6 +158,26 @@ class Sidebar(Gtk.Window):
         """Reset the tracked chat page reference when the window closes."""
 
         self._chat_page = None
+        return False
+
+    def show_account_dialog(self):
+        """Open the account management dialog."""
+
+        if not self.ATLAS.is_initialized():
+            self.show_error_dialog("ATLAS is not fully initialized. Please try again later.")
+            return
+
+        if self._account_dialog is None:
+            dialog = AccountDialog(self.ATLAS, self)
+            dialog.connect("close-request", self._on_account_dialog_close_request)
+            self._account_dialog = dialog
+
+        self._account_dialog.present()
+
+    def _on_account_dialog_close_request(self, *_args):
+        """Clear account dialog tracking once the window closes."""
+
+        self._account_dialog = None
         return False
 
     def show_persona_menu(self):

--- a/tests/test_account_dialog.py
+++ b/tests/test_account_dialog.py
@@ -1,0 +1,152 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import tests.test_chat_async_helper  # noqa: F401 - ensure GTK stubs are registered
+from GTKUI.UserAccounts.account_dialog import AccountDialog
+
+
+class _AtlasStub:
+    def __init__(self):
+        self.logger = SimpleNamespace(error=lambda *args, **kwargs: None)
+        self.active_username = None
+        self.active_display_name = "Guest"
+        self.last_factory = None
+        self.last_success = None
+        self.last_error = None
+        self.last_thread_name = None
+        self.login_result = True
+        self.register_result = {"username": "new-user"}
+        self.logout_called = False
+        self.login_called = None
+        self.register_called = None
+        self.config_manager = SimpleNamespace(get_active_user=lambda: self.active_username)
+
+    def add_active_user_change_listener(self, listener):
+        self.active_listener = listener
+        listener(self.active_username or "", self.active_display_name)
+
+    def remove_active_user_change_listener(self, listener):
+        if getattr(self, "active_listener", None) == listener:
+            self.active_listener = None
+
+    def run_in_background(self, factory, *, on_success=None, on_error=None, thread_name=None):
+        self.last_factory = factory
+        self.last_success = on_success
+        self.last_error = on_error
+        self.last_thread_name = thread_name
+        return SimpleNamespace()
+
+    async def login_user_account(self, username, password):
+        self.login_called = (username, password)
+        return self.login_result
+
+    async def register_user_account(self, username, password, email, name, dob):
+        self.register_called = (username, password, email, name, dob)
+        return self.register_result
+
+    async def logout_active_user(self):
+        self.logout_called = True
+        return None
+
+    def get_user_display_name(self):
+        return self.active_display_name
+
+
+@pytest.fixture(autouse=True)
+def disable_css(monkeypatch):
+    monkeypatch.setattr("GTKUI.UserAccounts.account_dialog.apply_css", lambda: None)
+
+
+def _drain_background(atlas: _AtlasStub):
+    assert atlas.last_factory is not None
+    coro = atlas.last_factory()
+    result = asyncio.get_event_loop().run_until_complete(coro)
+    if atlas.last_success is not None:
+        atlas.last_success(result)
+    return result
+
+
+def test_login_uses_background_worker():
+    atlas = _AtlasStub()
+    dialog = AccountDialog(atlas)
+
+    dialog.login_username_entry.set_text("alice")
+    dialog.login_password_entry.set_text("secret")
+
+    dialog._on_login_clicked(dialog.login_button)
+
+    assert atlas.last_thread_name == "user-login"
+    result = _drain_background(atlas)
+    assert result is True
+    assert atlas.login_called == ("alice", "secret")
+    assert getattr(dialog, "closed", False)
+
+
+def test_login_failure_displays_error():
+    atlas = _AtlasStub()
+    atlas.login_result = False
+    dialog = AccountDialog(atlas)
+
+    dialog.login_username_entry.set_text("alice")
+    dialog.login_password_entry.set_text("bad")
+
+    dialog._on_login_clicked(dialog.login_button)
+    _drain_background(atlas)
+
+    assert dialog.login_feedback_label.get_text() == "Invalid username or password."
+    assert not getattr(dialog, "closed", False)
+
+
+def test_register_validates_and_submits():
+    atlas = _AtlasStub()
+    dialog = AccountDialog(atlas)
+
+    dialog.register_username_entry.set_text("newuser")
+    dialog.register_email_entry.set_text("user@example.com")
+    dialog.register_password_entry.set_text("pw123")
+    dialog.register_confirm_entry.set_text("pw123")
+    dialog.register_name_entry.set_text("Test User")
+    dialog.register_dob_entry.set_text("2000-01-01")
+
+    dialog._on_register_clicked(dialog.register_button)
+
+    assert atlas.last_thread_name == "user-register"
+    _drain_background(atlas)
+    assert atlas.register_called == (
+        "newuser",
+        "pw123",
+        "user@example.com",
+        "Test User",
+        "2000-01-01",
+    )
+    assert getattr(dialog, "closed", False)
+
+
+def test_register_rejects_mismatched_passwords():
+    atlas = _AtlasStub()
+    dialog = AccountDialog(atlas)
+
+    dialog.register_username_entry.set_text("newuser")
+    dialog.register_email_entry.set_text("user@example.com")
+    dialog.register_password_entry.set_text("pw123")
+    dialog.register_confirm_entry.set_text("other")
+
+    dialog._on_register_clicked(dialog.register_button)
+
+    assert atlas.last_factory is None
+    assert dialog.register_feedback_label.get_text() == "Passwords do not match."
+
+
+def test_logout_invokes_background_worker():
+    atlas = _AtlasStub()
+    atlas.active_username = "alice"
+    dialog = AccountDialog(atlas)
+
+    dialog._on_logout_clicked(dialog.logout_button)
+
+    assert atlas.last_thread_name == "user-logout"
+    _drain_background(atlas)
+    assert atlas.logout_called is True
+    assert dialog.status_label.get_text() == "Signed out."

--- a/tests/test_atlas_active_user.py
+++ b/tests/test_atlas_active_user.py
@@ -1,0 +1,120 @@
+import asyncio
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from ATLAS import ATLAS as atlas_module
+from ATLAS.ATLAS import ATLAS
+
+
+@pytest.fixture(autouse=True)
+def patch_run_async_in_thread(monkeypatch):
+    async def immediate(func, *args, **kwargs):
+        result = func(*args, **kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+
+    monkeypatch.setattr(atlas_module, "run_async_in_thread", immediate)
+
+
+class _AccountServiceStub:
+    def __init__(self):
+        self.users: dict[str, dict[str, object]] = {}
+        self.active_user: str | None = None
+
+    def register_user(self, username, password, email, name=None, dob=None):
+        account = SimpleNamespace(
+            id=len(self.users) + 1,
+            username=username,
+            email=email,
+            name=name,
+            dob=dob,
+        )
+        self.users[username] = {"account": account, "password": password}
+        return account
+
+    def authenticate_user(self, username, password):
+        record = self.users.get(username)
+        if not record:
+            return False
+        return record["password"] == password
+
+    def set_active_user(self, username):
+        self.active_user = username
+
+    def get_active_user(self):
+        return self.active_user
+
+    def list_users(self):
+        rows = []
+        for username, payload in self.users.items():
+            account = payload["account"]
+            rows.append(
+                {
+                    "id": account.id,
+                    "username": account.username,
+                    "email": account.email,
+                    "name": account.name,
+                    "dob": account.dob,
+                }
+            )
+        rows.sort(key=lambda row: row["username"].lower())
+        return rows
+
+
+class _PersonaManagerStub:
+    def __init__(self):
+        self.user_updates: list[str] = []
+
+    def set_user(self, username):
+        self.user_updates.append(username)
+
+
+def test_active_user_listener_receives_register_and_login_updates():
+    atlas = ATLAS()
+    service = _AccountServiceStub()
+    persona_manager = _PersonaManagerStub()
+    atlas._user_account_service = service
+    atlas.persona_manager = persona_manager
+
+    events = []
+
+    def listener(username, display_name):
+        events.append((username, display_name))
+
+    atlas.add_active_user_change_listener(listener)
+    events.clear()
+
+    asyncio.run(atlas.register_user_account("alice", "pw123", "alice@example.com", name="Alice"))
+    assert events[-1] == ("alice", "Alice")
+    assert persona_manager.user_updates[-1] == "alice"
+
+    asyncio.run(atlas.logout_active_user())
+    events.clear()
+    asyncio.run(atlas.login_user_account("alice", "pw123"))
+    assert events[-1] == ("alice", "Alice")
+    assert persona_manager.user_updates[-1] == "alice"
+
+
+def test_logout_notifies_listeners_with_generic_identity():
+    atlas = ATLAS()
+    service = _AccountServiceStub()
+    persona_manager = _PersonaManagerStub()
+    atlas._user_account_service = service
+    atlas.persona_manager = persona_manager
+
+    events = []
+
+    atlas.add_active_user_change_listener(lambda username, display: events.append((username, display)))
+    events.clear()
+
+    asyncio.run(atlas.register_user_account("bob", "pw", "bob@example.com", name="Bob"))
+    events.clear()
+
+    asyncio.run(atlas.logout_active_user())
+    assert events, "Expected logout to trigger an event"
+    username, display = events[-1]
+    assert username != "bob"
+    assert persona_manager.user_updates[-1] != "bob"


### PR DESCRIPTION
## Summary
- add a GTK account dialog with login, registration, and logout flows wired to ATLAS account APIs
- emit and consume an active-user-changed signal so personas and chat windows update immediately after account switches
- extend sidebar and tests to cover the new account management UI and user change behavior

## Testing
- pytest tests/test_account_dialog.py tests/test_atlas_active_user.py tests/test_chat_async_helper.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ac99defc8322932e762f2f848771