### PR TITLE
Add user account deletion workflow

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -304,6 +304,17 @@ class ATLAS:
         await run_async_in_thread(service.set_active_user, None)
         self._refresh_active_user_identity(prefer_generic=True)
 
+    async def delete_user_account(self, username: str) -> None:
+        """Delete a stored user account via the service layer."""
+
+        service = self._get_user_account_service()
+        deleted = await run_async_in_thread(service.delete_user, username)
+
+        if not deleted:
+            raise ValueError(f"Unknown user: {username}")
+
+        self._refresh_active_user_identity(prefer_generic=True)
+
     def _require_provider_manager(self) -> ProviderManager:
         """Return the initialized provider manager or raise an error if unavailable."""
 

--- a/modules/user_accounts/user_account_service.py
+++ b/modules/user_accounts/user_account_service.py
@@ -158,6 +158,33 @@ class UserAccountService:
 
         return self.config_manager.set_active_user(normalised_username)
 
+    def delete_user(self, username: str) -> bool:
+        """Remove a user account and clear it from configuration if active."""
+
+        normalised_username = self._normalise_username(username)
+        if not normalised_username:
+            raise ValueError("Username must not be empty")
+
+        active_user = self.get_active_user()
+        deleted = self._database.delete_user(normalised_username)
+
+        if not deleted:
+            self.logger.info(
+                "No user found with username '%s' to delete", normalised_username
+            )
+            return False
+
+        if active_user == normalised_username:
+            self.config_manager.set_active_user(None)
+            self.logger.info(
+                "Deleted active user '%s' and cleared active user selection",
+                normalised_username,
+            )
+        else:
+            self.logger.info("Deleted user '%s'", normalised_username)
+
+        return True
+
     def close(self) -> None:
         """Release resources associated with the service."""
 


### PR DESCRIPTION
## Summary
- add a database helper to delete user rows and remove stored profile files
- extend the user account service to clear the active user and log when deleting accounts
- expose an async deletion helper on the main ATLAS class and cover the behaviour with new tests

## Testing
- pytest tests/test_user_account_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2bd362ba88322a58e92a503cf5b17