### PR TITLE
Ensure EMR files are removed with user deletion

### DIFF
--- a/tests/test_user_account_service.py
+++ b/tests/test_user_account_service.py
@@ -226,11 +226,14 @@ def test_delete_user_removes_record_and_profile(tmp_path, monkeypatch):
         service.register_user('henry', 'Password1', 'henry@example.com')
         profile_path = Path(service._database.user_profiles_dir) / 'henry.json'
         profile_path.write_text('{"name": "Henry"}', encoding='utf-8')
+        emr_path = Path(service._database.user_profiles_dir) / 'henry_emr.txt'
+        emr_path.write_text('EMR data', encoding='utf-8')
 
         deleted = service.delete_user('henry')
 
         assert deleted is True
         assert not profile_path.exists()
+        assert not emr_path.exists()
         assert service.list_users() == []
         assert any(
             args[0] == "Deleted user '%s'" and args[1] == 'henry'


### PR DESCRIPTION
## Summary
- delete the EMR companion file alongside the JSON profile when removing a user account
- extend the service-level deletion test to assert EMR cleanup
- add a database unit test that covers profile and EMR removal

## Testing
- pytest tests/test_user_account_service.py::test_delete_user_removes_record_and_profile tests/test_user_account_db.py::test_delete_user_removes_profile_and_emr

------
https://chatgpt.com/codex/tasks/task_e_68e2c88efddc8322953e7b0d4b7011b0