### PR TITLE
Handle missing Windows memory capacity data

### DIFF
--- a/modules/user_accounts/user_data_manager.py
+++ b/modules/user_accounts/user_data_manager.py
@@ -73,8 +73,17 @@ class SystemInfo:
         """Gets memory information based on the OS."""
         if platform.system() == "Windows":
             output = SystemInfo.run_command("wmic MemoryChip get Capacity /format:list")
-            total_memory = sum([int(re.search(r'Capacity=(\d+)', line).group(1)) for line in output.splitlines() if "Capacity" in line])
-            return f"Total Physical Memory: {total_memory / (1024**3):.2f} GB"
+            capacities = []
+            for line in output.splitlines():
+                match = re.search(r"Capacity=(\d+)", line)
+                if match:
+                    capacities.append(int(match.group(1)))
+
+            if capacities:
+                total_memory = sum(capacities)
+                return f"Total Physical Memory: {total_memory / (1024**3):.2f} GB"
+
+            return "Total Physical Memory: Unknown"
         else:
             output = SystemInfo.run_command("free -h")
         return output

--- a/tests/test_user_data_manager.py
+++ b/tests/test_user_data_manager.py
@@ -78,3 +78,31 @@ def test_system_info_lazy_loading_and_caching(monkeypatch):
     assert call_count['count'] == 10
 
     UserDataManager.invalidate_system_info_cache()
+
+
+def test_get_memory_info_handles_missing_capacity(monkeypatch):
+    SystemInfo = user_data_manager_module.SystemInfo
+
+    monkeypatch.setattr(user_data_manager_module.platform, 'system', lambda: 'Windows')
+
+    sample_output = """BankLabel=NODE 0 DIMM 0\nCapacity=17179869184\n\nBankLabel=NODE 0 DIMM 1\nManufacturer=Example"""
+
+    monkeypatch.setattr(SystemInfo, 'run_command', staticmethod(lambda _command: sample_output))
+
+    result = SystemInfo.get_memory_info()
+
+    assert result == "Total Physical Memory: 16.00 GB"
+
+
+def test_get_memory_info_handles_no_capacity_data(monkeypatch):
+    SystemInfo = user_data_manager_module.SystemInfo
+
+    monkeypatch.setattr(user_data_manager_module.platform, 'system', lambda: 'Windows')
+
+    sample_output = """BankLabel=NODE 0 DIMM 0\nManufacturer=Example"""
+
+    monkeypatch.setattr(SystemInfo, 'run_command', staticmethod(lambda _command: sample_output))
+
+    result = SystemInfo.get_memory_info()
+
+    assert result == "Total Physical Memory: Unknown"


### PR DESCRIPTION
## Summary
- guard memory info parsing against missing WMIC Capacity lines and return "Unknown" when none are found
- add regression tests covering partial and missing Capacity data

## Testing
- pytest tests/test_user_data_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e2d250cda8832286e7da8c265c5fed