### PR TITLE
Ensure email updates refresh user profiles

### DIFF
--- a/modules/user_accounts/user_account_db.py
+++ b/modules/user_accounts/user_account_db.py
@@ -298,6 +298,7 @@ class UserAccountDatabase:
 
     def update_user(self, username, password=None, email=None, name=None, dob=None):
         profile_data = None
+        profile_fields_modified = False
         with self._lock:
             cursor = self.conn.cursor()
             try:
@@ -315,15 +316,18 @@ class UserAccountDatabase:
                 if email is not None:
                     query = "UPDATE user_accounts SET email = ? WHERE username = ?"
                     _execute_update(query, (email, username))
+                    profile_fields_modified = True
                 if name is not None:
                     query = "UPDATE user_accounts SET name = ? WHERE username = ?"
                     _execute_update(query, (name, username))
+                    profile_fields_modified = True
                 if dob is not None:
                     query = "UPDATE user_accounts SET DOB = ? WHERE username = ?"
                     _execute_update(query, (dob, username))
+                    profile_fields_modified = True
                 self.conn.commit()
 
-                if name is not None or dob is not None:
+                if profile_fields_modified:
                     cursor.execute(
                         "SELECT username, email, name, DOB FROM user_accounts WHERE username = ?",
                         (username,),

--- a/tests/test_user_account_db.py
+++ b/tests/test_user_account_db.py
@@ -151,6 +151,24 @@ def test_update_user_refreshes_profile(tmp_path, monkeypatch):
         db.close_connection()
 
 
+def test_update_user_refreshes_profile_on_email_change(tmp_path, monkeypatch):
+    db = _create_db(tmp_path, monkeypatch)
+
+    try:
+        db.add_user('frank', 'Password1', 'frank@example.com', 'Frank', '1985-06-07')
+
+        profile_path = Path(db.user_profiles_dir) / 'frank.json'
+
+        db.update_user('frank', email='frank.new@example.com')
+
+        updated = json.loads(profile_path.read_text(encoding='utf-8'))
+        assert updated['Email'] == 'frank.new@example.com'
+        assert updated['Full Name'] == 'Frank'
+        assert updated['DOB'] == '1985-06-07'
+    finally:
+        db.close_connection()
+
+
 def test_database_uses_app_root_directory(tmp_path, monkeypatch):
     app_root = tmp_path / 'app-root'
     _install_config_manager_stub(monkeypatch, str(app_root))


### PR DESCRIPTION
## Summary
- ensure `update_user` refreshes cached profile data whenever email, name, or DOB are updated
- simplify profile refresh logic by fetching the updated row once after modifying profile fields
- add a regression test that verifies email-only updates rewrite the profile JSON

## Testing
- pytest tests/test_user_account_db.py

------
https://chatgpt.com/codex/tasks/task_e_68e2d709600c8322b41a59ce3bf31365