### PR TITLE
Refresh persona manager caches after profile edits

### DIFF
--- a/ATLAS/persona_manager.py
+++ b/ATLAS/persona_manager.py
@@ -107,10 +107,19 @@ class PersonaManager:
         """Update personalization state for a new active user."""
 
         sanitized = (user or "User").strip() or "User"
-        if sanitized == self.user:
-            return
-
         self.user = sanitized
+
+        try:
+            invalidate_cache = getattr(UserDataManager, "invalidate_system_info_cache")
+        except AttributeError:
+            invalidate_cache = None
+
+        if callable(invalidate_cache):
+            try:
+                invalidate_cache()
+            except Exception:  # pragma: no cover - defensive logging only
+                self.logger.warning("Failed to invalidate shared system info cache", exc_info=True)
+
         self.user_data_manager = UserDataManager(self.user)
 
         if self.current_persona is not None:


### PR DESCRIPTION
## Summary
- rebuild the persona manager's user data manager whenever set_user is called
- invalidate shared system information caches before recreating the manager
- extend persona manager tests with a cached stub and coverage for updating the active profile

## Testing
- pytest tests/test_persona_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ebc7e7f8832293ffabfd938984e8