### PR TITLE
Handle synchronous callables in run_async_in_thread

### DIFF
--- a/tests/test_user_account_service.py
+++ b/tests/test_user_account_service.py
@@ -267,6 +267,26 @@ def test_concurrent_database_access_is_serialised(tmp_path, monkeypatch):
         service.close()
 
 
+def test_run_async_in_thread_accepts_sync_callables(tmp_path, monkeypatch):
+    service, _ = _create_service(tmp_path, monkeypatch)
+
+    try:
+        account_future = run_async_in_thread(
+            service.register_user,
+            'alice',
+            'Password123',
+            'alice@example.com',
+        )
+        account = account_future.result(timeout=5)
+        assert account.username == 'alice'
+
+        users_future = run_async_in_thread(service.list_users)
+        users = users_future.result(timeout=5)
+        assert users and users[0]['username'] == 'alice'
+    finally:
+        service.close()
+
+
 def test_delete_user_removes_record_and_profile(tmp_path, monkeypatch):
     service, _ = _create_service(tmp_path, monkeypatch)
 


### PR DESCRIPTION
## Summary
- allow background task helper to pass positional and keyword arguments to the callable
- detect synchronous results and avoid awaiting them before completing the future
- add regression coverage to ensure user account service operations work when dispatched through run_async_in_thread

## Testing
- pytest tests/test_user_account_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e30b69693083228e5f57665e6386db