### PR TITLE
Fix account dialog toggle highlighting for edit form

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -753,6 +753,7 @@ class AccountDialog(Gtk.Window):
     # ------------------------------------------------------------------
     def _show_form(self, name: str) -> None:
         if name == self._active_form:
+            self._update_toggle_buttons()
             return
 
         for form_name, widget in self._forms.items():
@@ -767,12 +768,18 @@ class AccountDialog(Gtk.Window):
         self._update_toggle_buttons()
 
     def _update_toggle_buttons(self) -> None:
-        if self._active_form == "login":
+        login_active = self._active_form == "login"
+        register_active = self._active_form == "register"
+
+        if login_active:
             self.login_toggle_button.add_css_class("suggested-action")
-            self.register_toggle_button.remove_css_class("suggested-action")
         else:
-            self.register_toggle_button.add_css_class("suggested-action")
             self.login_toggle_button.remove_css_class("suggested-action")
+
+        if register_active:
+            self.register_toggle_button.add_css_class("suggested-action")
+        else:
+            self.register_toggle_button.remove_css_class("suggested-action")
 
     # ------------------------------------------------------------------
     # Login flow

--- a/tests/test_account_dialog.py
+++ b/tests/test_account_dialog.py
@@ -114,6 +114,24 @@ def _click(button):
             break
 
 
+def test_form_toggle_highlighting():
+    atlas = _AtlasStub()
+    dialog = AccountDialog(atlas)
+    if atlas.last_factory is not None:
+        _drain_background(atlas)
+
+    assert dialog.login_toggle_button.has_css_class("suggested-action")
+    assert not dialog.register_toggle_button.has_css_class("suggested-action")
+
+    dialog._show_form("register")
+    assert dialog.register_toggle_button.has_css_class("suggested-action")
+    assert not dialog.login_toggle_button.has_css_class("suggested-action")
+
+    dialog._show_form("edit")
+    assert not dialog.login_toggle_button.has_css_class("suggested-action")
+    assert not dialog.register_toggle_button.has_css_class("suggested-action")
+
+
 def test_login_uses_background_worker():
     atlas = _AtlasStub()
     dialog = AccountDialog(atlas)

--- a/tests/test_chat_async_helper.py
+++ b/tests/test_chat_async_helper.py
@@ -23,6 +23,7 @@ class _DummyWidget:
         self._valign = None
         self._sensitive = True
         self.visible = True
+        self._css_classes: set[str] = set()
 
     def __call__(self, *args, **kwargs):  # pragma: no cover - convenience hook
         return self
@@ -33,8 +34,16 @@ class _DummyWidget:
     def connect(self, *_args, **_kwargs):  # pragma: no cover - event helper
         return None
 
-    def add_css_class(self, *_args, **_kwargs):  # pragma: no cover - styling helper
+    def add_css_class(self, name, *_args, **_kwargs):  # pragma: no cover - styling helper
+        self._css_classes.add(name)
         return None
+
+    def remove_css_class(self, name, *_args, **_kwargs):  # pragma: no cover - styling helper
+        self._css_classes.discard(name)
+        return None
+
+    def has_css_class(self, name):  # pragma: no cover - styling helper
+        return name in self._css_classes
 
     def get_style_context(self):  # pragma: no cover - styling helper
         return self


### PR DESCRIPTION
## Summary
- ensure the account dialog toggle buttons update consistently across login, register, and edit states
- reset toggle styling for the edit state while keeping the appropriate button highlighted for login/register
- extend the GTK testing stubs and add regression coverage for the toggle styling behavior

## Testing
- pytest tests/test_account_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68e30d92a0508322920192f2dba2b400