### PR TITLE
Handle SearchEntry placeholder compatibility

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -156,7 +156,15 @@ class AccountDialog(Gtk.Window):
 
         search_entry_cls = getattr(Gtk, "SearchEntry", Gtk.Entry)
         self.account_search_entry = search_entry_cls()
-        self.account_search_entry.set_placeholder_text("Search by username, email or name")
+        placeholder_text = "Search by username, email or name"
+        set_placeholder = getattr(self.account_search_entry, "set_placeholder_text", None)
+        if callable(set_placeholder):
+            set_placeholder(placeholder_text)
+        else:  # pragma: no cover - compatibility fallback
+            try:
+                self.account_search_entry.set_property("placeholder-text", placeholder_text)
+            except Exception:
+                pass
         connectable_signals = ["changed", "search-changed"]
         for signal in connectable_signals:
             connect = getattr(self.account_search_entry, "connect", None)


### PR DESCRIPTION
## Summary
- guard account search placeholder assignment to support SearchEntry widgets lacking set_placeholder_text
- fall back to setting the placeholder-text property when the method is unavailable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e31327056883228e91ff68559249f8