### PR TITLE
Make background task futures awaitable

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -320,21 +320,16 @@ class ATLAS:
 
         service = self._get_user_account_service()
 
-        async def _load_active() -> Optional[str]:
-            return service.get_active_user()
+        active_username = await run_async_in_thread(service.get_active_user)
 
-        active_username = await run_async_in_thread(_load_active)
-
-        async def _perform_update() -> Any:
-            return service.update_user(
-                username,
-                password=password,
-                email=email,
-                name=name,
-                dob=dob,
-            )
-
-        account = await run_async_in_thread(_perform_update)
+        account = await run_async_in_thread(
+            service.update_user,
+            username,
+            password=password,
+            email=email,
+            name=name,
+            dob=dob,
+        )
 
         if active_username and account.username == active_username:
             await run_async_in_thread(service.set_active_user, account.username)

--- a/tests/test_atlas_user_accounts_async.py
+++ b/tests/test_atlas_user_accounts_async.py
@@ -1,0 +1,32 @@
+import asyncio
+
+from ATLAS.ATLAS import ATLAS
+
+
+class _StubService:
+    def __init__(self, users):
+        self._users = users
+
+    def list_users(self):
+        return list(self._users)
+
+
+def _make_atlas_with_service(users):
+    atlas = ATLAS()
+    atlas._user_account_service = _StubService(users)
+    return atlas
+
+
+def test_list_user_accounts_is_awaitable():
+    atlas = _make_atlas_with_service([
+        {"username": "alice", "name": "Alice"},
+        {"username": "bob", "name": "Bob"},
+    ])
+
+    result = asyncio.run(atlas.list_user_accounts())
+
+    assert result == [
+        {"username": "alice", "name": "Alice"},
+        {"username": "bob", "name": "Bob"},
+    ]
+


### PR DESCRIPTION
## Summary
- make `run_async_in_thread` return an awaitable future so async callers can `await` it safely
- simplify the ATLAS account update flow to rely on the awaitable background task helper
- add regression tests covering async account listing and the account dialog refresh path

## Testing
- pytest tests/test_atlas_user_accounts_async.py tests/test_account_dialog.py::test_refresh_account_list_handles_async_accounts
- pytest tests/test_user_account_service.py::test_run_async_in_thread_accepts_sync_callables

------
https://chatgpt.com/codex/tasks/task_e_68e3e27dfb648322992d5b866681e4a3