### PR TITLE
Implement temporary login lockouts with UI feedback

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover - fall back gracefully when Gio is missing
 
 from GTKUI.Utils.utils import apply_css, create_box
 from modules.user_accounts.user_account_service import (
+    AccountLockedError,
     DuplicateUserError,
     InvalidCurrentPasswordError,
 )
@@ -1523,7 +1524,10 @@ class AccountDialog(Gtk.Window):
 
     def _handle_login_error(self, exc: Exception) -> bool:
         self._set_login_busy(False)
-        self.login_feedback_label.set_text(f"Login failed: {exc}")
+        if isinstance(exc, AccountLockedError):
+            self.login_feedback_label.set_text(str(exc))
+        else:
+            self.login_feedback_label.set_text(f"Login failed: {exc}")
         return False
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add configurable per-username login lockout tracking to `UserAccountService` and raise `AccountLockedError` when too many failures occur
- update the GTK account dialog to surface a clear lockout message on login failures
- extend service and UI unit tests to cover lockout triggering, expiry, and reset on success

## Testing
- pytest tests/test_user_account_service.py
- pytest tests/test_account_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68e3ec8dbf5c8322a25755120a027c34