### PR TITLE
Handle login entry activation in account dialog

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -1219,6 +1219,12 @@ class AccountDialog(Gtk.Window):
         self.login_button.connect("clicked", self._on_login_clicked)
         wrapper.append(self.login_button)
 
+        def trigger_login_from_entry(*_args) -> None:
+            self._on_login_clicked(self.login_button)
+
+        self.login_username_entry.connect("activate", trigger_login_from_entry)
+        self.login_password_entry.connect("activate", trigger_login_from_entry)
+
         return wrapper
 
     def _build_registration_form(self) -> Gtk.Widget:


### PR DESCRIPTION
## Summary
- trigger the login button handler when the username or password entry emits activate
- add a regression test that simulates activating the password entry and asserts the login flow starts

## Testing
- pytest tests/test_account_dialog.py::test_login_entry_activate_triggers_login


------
https://chatgpt.com/codex/tasks/task_e_68e3ef27eb5c8322a3ded927d56d0eb4