### PR TITLE
Prevent duplicate login attempts when busy

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -49,6 +49,7 @@ class AccountDialog(Gtk.Window):
         self._account_filter_text: str = ""
         self._selected_username: Optional[str] = None
         self._details_busy = False
+        self._login_busy = False
         self._visible_usernames: list[str] = []
         self._password_toggle_buttons: list[Gtk.Widget] = []
         self._password_requirements: Optional[PasswordRequirements] = None
@@ -1622,11 +1623,17 @@ class AccountDialog(Gtk.Window):
     # Login flow
     # ------------------------------------------------------------------
     def _set_login_busy(self, busy: bool, message: Optional[str] = None) -> None:
-        self.login_button.set_sensitive(not busy)
+        self._login_busy = bool(busy)
+        self._set_widget_sensitive(self.login_button, not busy)
+        self._set_widget_sensitive(self.login_username_entry, not busy)
+        self._set_widget_sensitive(self.login_password_entry, not busy)
         if message is not None:
             self.login_feedback_label.set_text(message)
 
     def _on_login_clicked(self, _button) -> None:
+        if self._login_busy:
+            return
+
         username = (self.login_username_entry.get_text() or "").strip()
         password = self.login_password_entry.get_text() or ""
 


### PR DESCRIPTION
## Summary
- track login busy state to disable inputs during background authentication tasks
- guard login handler against repeated activation while the background job is running
- cover the busy state by extending the account dialog login entry tests

## Testing
- pytest tests/test_account_dialog.py::test_login_uses_background_worker tests/test_account_dialog.py::test_login_entry_activate_triggers_login
- pytest tests/test_account_dialog.py::test_login_entry_activate_ignored_when_busy

------
https://chatgpt.com/codex/tasks/task_e_68e3fc4d186c8322b3043e50a832e046