### PR TITLE
Disable edit form inputs while account updates run

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -2004,9 +2004,36 @@ class AccountDialog(Gtk.Window):
             grabber()
 
     def _set_edit_busy(self, busy: bool, message: Optional[str] = None) -> None:
-        self.edit_save_button.set_sensitive(not busy)
+        sensitive = not busy
+
+        widgets = [
+            self.edit_save_button,
+            self.edit_username_entry,
+            self.edit_email_entry,
+            self.edit_current_password_entry,
+            self.edit_password_entry,
+            self.edit_confirm_entry,
+            self.edit_name_entry,
+            self.edit_dob_entry,
+        ]
+
+        for widget in widgets:
+            self._set_widget_sensitive(widget, sensitive)
+
+        password_entries = (
+            self.edit_current_password_entry,
+            self.edit_password_entry,
+            self.edit_confirm_entry,
+        )
+
+        for entry in password_entries:
+            for toggle in self._password_toggle_buttons_by_entry.get(entry, []):
+                self._set_widget_sensitive(toggle, sensitive)
+
         if message is not None:
             self.edit_feedback_label.set_text(message)
+        elif not busy:
+            self.edit_feedback_label.set_text("")
 
     def _on_edit_save_clicked(self, _button) -> None:
         username = self._editing_username

--- a/tests/test_account_dialog.py
+++ b/tests/test_account_dialog.py
@@ -348,6 +348,43 @@ def test_register_user_validation():
     assert all(state is True for state in enabled_states), enabled_states
 
 
+def test_edit_form_disabled_when_busy():
+    atlas = _AtlasStub()
+    dialog = AccountDialog(atlas)
+    if atlas.last_factory is not None:
+        _drain_background(atlas)
+
+    toggle_widgets = []
+    for entry in (
+        dialog.edit_current_password_entry,
+        dialog.edit_password_entry,
+        dialog.edit_confirm_entry,
+    ):
+        toggle_widgets.extend(dialog._password_toggle_buttons_by_entry.get(entry, []))
+
+    widgets = [
+        dialog.edit_save_button,
+        dialog.edit_username_entry,
+        dialog.edit_email_entry,
+        dialog.edit_current_password_entry,
+        dialog.edit_password_entry,
+        dialog.edit_confirm_entry,
+        dialog.edit_name_entry,
+        dialog.edit_dob_entry,
+        *toggle_widgets,
+    ]
+
+    dialog._set_edit_busy(True, "Processing…")
+
+    disabled_states = [_is_sensitive(widget) for widget in widgets]
+    assert all(state is False for state in disabled_states), disabled_states
+
+    dialog._set_edit_busy(False)
+
+    enabled_states = [_is_sensitive(widget) for widget in widgets]
+    assert all(state is True for state in enabled_states), enabled_states
+
+
 def test_login_failure_displays_error():
     atlas = _AtlasStub()
     atlas.login_result = False
@@ -933,7 +970,7 @@ def test_delete_account_manual_dialog_requires_confirmation(monkeypatch):
     assert atlas.delete_called == "alice"
 
 
-def test_edit_account_prefills_and_updates():
+def test_edit_account_updates_fields():
     atlas = _AtlasStub()
     atlas.list_accounts_result = [
         {


### PR DESCRIPTION
## Summary
- update the account edit busy handler to disable form entries and password toggles while saving
- clear the busy message when work completes and ensure handlers restore sensitivity
- add a regression test covering the edit form busy state and rename the edit update test to the requested name

## Testing
- pytest tests/test_account_dialog.py::test_edit_account_updates_fields

------
https://chatgpt.com/codex/tasks/task_e_68e40194a42c8322bac98d147ad91717