### PR TITLE
Add tooltips for password requirements in account dialog

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -57,6 +57,7 @@ class AccountDialog(Gtk.Window):
         self._password_requirements: Optional[PasswordRequirements] = None
         self._password_requirements_text: str = ""
         self._password_requirement_labels: list[Gtk.Label] = []
+        self._password_requirement_tooltip_widgets: list[Gtk.Widget] = []
 
         self.set_modal(True)
         if parent is not None:
@@ -176,6 +177,14 @@ class AccountDialog(Gtk.Window):
         text = self._password_requirement_text()
         for label in self._password_requirement_labels:
             label.set_text(text)
+        tooltip = self._password_requirements_text or text
+        for widget in self._password_requirement_tooltip_widgets:
+            setter = getattr(widget, "set_tooltip_text", None)
+            if callable(setter):
+                try:
+                    setter(tooltip)
+                except Exception:  # pragma: no cover - stub compatibility
+                    continue
 
     def _initialise_password_requirements(self) -> None:
         requirements = self._default_password_requirements()
@@ -1425,6 +1434,9 @@ class AccountDialog(Gtk.Window):
         grid.attach(self.register_confirm_entry, 1, 3, 1, 1)
         register_confirm_toggle = self._create_password_toggle(self.register_confirm_entry)
         grid.attach(register_confirm_toggle, 2, 3, 1, 1)
+        self._password_requirement_tooltip_widgets.extend(
+            [self.register_password_entry, self.register_confirm_entry]
+        )
 
         self.register_password_strength_label = Gtk.Label()
         self.register_password_strength_label.set_xalign(0.0)
@@ -1538,6 +1550,9 @@ class AccountDialog(Gtk.Window):
 
         edit_confirm_toggle = self._create_password_toggle(self.edit_confirm_entry)
         grid.attach(edit_confirm_toggle, 2, 4, 1, 1)
+        self._password_requirement_tooltip_widgets.extend(
+            [self.edit_password_entry, self.edit_confirm_entry]
+        )
 
         self.edit_password_strength_label = Gtk.Label()
         self.edit_password_strength_label.set_xalign(0.0)

--- a/tests/test_account_dialog.py
+++ b/tests/test_account_dialog.py
@@ -198,6 +198,32 @@ def test_form_toggle_highlighting():
     assert not dialog.register_toggle_button.has_css_class("suggested-action")
 
 
+def test_password_requirements_rendered():
+    atlas = _AtlasStub()
+    dialog = AccountDialog(atlas)
+    if atlas.last_factory is not None:
+        _drain_background(atlas)
+
+    expected = atlas.describe_user_password_requirements()
+    widgets = [
+        dialog.register_password_entry,
+        dialog.register_confirm_entry,
+        dialog.edit_password_entry,
+        dialog.edit_confirm_entry,
+    ]
+
+    for widget in widgets:
+        tooltip = getattr(widget, "_tooltip", None)
+        assert tooltip is not None
+        assert expected in tooltip
+
+    dialog._password_requirements_text = "Use a memorable passphrase"
+    dialog._update_password_requirement_labels()
+
+    for widget in widgets:
+        assert getattr(widget, "_tooltip", None) == "Use a memorable passphrase"
+
+
 def test_password_toggle_icon_press_updates_state_and_label():
     atlas = _AtlasStub()
     dialog = AccountDialog(atlas)


### PR DESCRIPTION
## Summary
- register password entry widgets so password requirements guidance can be shown as tooltips
- update the password requirements refresh helper to propagate descriptive text to tooltips
- extend the account dialog tests to cover the rendered password requirement guidance

## Testing
- pytest tests/test_account_dialog.py::test_password_requirements_rendered

------
https://chatgpt.com/codex/tasks/task_e_68e40383b8e083229fee7cfdd68234c3