### PR TITLE
Fix observation key typo in user profile template

### DIFF
--- a/modules/user_accounts/user_template
+++ b/modules/user_accounts/user_template
@@ -9,14 +9,14 @@
             "",
             ""
         ],
-        "obsevations": ""
+        "observations": ""
     },
     "Location": {
         "Content": "",
-        "obsevations": ""
+        "observations": ""
     },
     "Occupation": {
         "Content": "",
-        "obsevations": ""
+        "observations": ""
     }
 }

--- a/tests/test_user_account_db.py
+++ b/tests/test_user_account_db.py
@@ -90,6 +90,9 @@ def test_add_user_creates_profile_files(tmp_path, monkeypatch):
         assert profile_contents['Full Name'] == 'Dave'
         assert profile_contents['DOB'] == '1995-09-01'
         assert profile_contents['Email'] == 'dave@example.com'
+        assert profile_contents['Interests']['observations'] == ''
+        assert profile_contents['Location']['observations'] == ''
+        assert profile_contents['Occupation']['observations'] == ''
 
         assert emr_path.exists()
         assert emr_path.read_text(encoding='utf-8') == ''


### PR DESCRIPTION
## Summary
- rename the misspelled `obsevations` keys in the user profile template to `observations`
- extend the user account database test to assert the corrected key is written when profiles are created

## Testing
- pytest tests/test_user_account_db.py tests/test_user_data_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e40524f5e883228cfc20d6a92e8405