### PR TITLE
feat: allow configuring user password policy

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -208,9 +208,16 @@ class AccountDialog(Gtk.Window):
             except Exception as exc:  # pragma: no cover - descriptive text optional
                 self.logger.debug("Failed to describe password requirements: %s", exc)
 
-        self._password_requirements = requirements
-        self._password_requirements_text = description or requirements.describe()
-        self._update_password_requirement_labels()
+        resolved_description = description or requirements.describe()
+
+        if (
+            self._password_requirements is None
+            or requirements != self._password_requirements
+            or resolved_description != self._password_requirements_text
+        ):
+            self._password_requirements = requirements
+            self._password_requirements_text = resolved_description
+            self._update_password_requirement_labels()
 
     def _build_account_section(self) -> Gtk.Widget:
         wrapper = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=8, margin=0)

--- a/docs/password-policy.md
+++ b/docs/password-policy.md
@@ -1,0 +1,24 @@
+# Password Policy Configuration
+
+ATLAS enforces a password policy for local user accounts. Deployments can
+customise the requirements by setting the following configuration keys in
+`config.yaml` or via environment variables. Any values omitted fall back to the
+secure defaults bundled with the application.
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `ACCOUNT_PASSWORD_MIN_LENGTH` | Minimum password length in characters. Provide a positive integer. | `10` |
+| `ACCOUNT_PASSWORD_REQUIRE_UPPERCASE` | Require at least one uppercase letter (`A-Z`). Accepts truthy/falsey strings such as `"true"`/`"false"`, numeric flags, or booleans. | `true` |
+| `ACCOUNT_PASSWORD_REQUIRE_LOWERCASE` | Require at least one lowercase letter (`a-z`). | `true` |
+| `ACCOUNT_PASSWORD_REQUIRE_DIGIT` | Require at least one number (`0-9`). | `true` |
+| `ACCOUNT_PASSWORD_REQUIRE_SYMBOL` | Require at least one symbol (for example `!`, `@`, or `#`). | `true` |
+| `ACCOUNT_PASSWORD_FORBID_WHITESPACE` | Disallow spaces or other whitespace characters in passwords. | `true` |
+
+Values supplied for boolean options are interpreted case-insensitively. Accepted
+truthy values are `true`, `yes`, `on`, and `1`; falsey values include `false`,
+`no`, `off`, and `0`. Any invalid values are ignored with a warning and the
+default behaviour is preserved.
+
+After updating the configuration, restart ATLAS to apply the new policy. The UI
+will automatically refresh its password guidance text the next time the account
+dialog is opened.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,4 +9,7 @@
   configured application root (or explicit speech cache settings), ensuring
   custom installations store generated audio in the expected location and log
   permission issues clearly.
+- User account password policies can now be customised via configuration keys
+  for minimum length and character requirements. See `docs/password-policy.md`
+  for the full list of options.
 


### PR DESCRIPTION
## Summary
- read optional password policy overrides from configuration when initialising `UserAccountService`
- refresh the account dialog password guidance when requirements change and cover configurable behaviour with tests
- document the new configuration keys for deployments adjusting password rules

## Testing
- `pytest tests/test_user_account_service.py tests/test_account_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68e41073b3d48322aba0adc017509828