### PR TITLE
Update login entry when active user changes

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -1772,6 +1772,12 @@ class AccountDialog(Gtk.Window):
             message = "No active account"
 
         self.status_label.set_text(message)
+        entry = getattr(self, "login_username_entry", None)
+        if entry is not None:
+            if username:
+                entry.set_text(username)
+            elif not persisted:
+                entry.set_text("")
         try:
             self.logout_button.set_sensitive(bool(persisted))
         except Exception:  # pragma: no cover - stub safety

--- a/tests/test_account_dialog.py
+++ b/tests/test_account_dialog.py
@@ -994,6 +994,26 @@ def test_account_list_populates_and_highlights_active():
     assert dialog._account_rows["bob"]["use_button"]._sensitive is True
 
 
+def test_active_user_state_updates_login_entry():
+    atlas = _AtlasStub()
+    dialog = AccountDialog(atlas)
+    if atlas.last_factory is not None:
+        _drain_background(atlas)
+
+    assert dialog.login_username_entry.get_text() == ""
+
+    atlas.active_username = "carol"
+    dialog._apply_active_user_state("carol", "Carol")
+
+    assert dialog.login_username_entry.get_text() == "carol"
+
+    dialog.login_username_entry.set_text("should be cleared")
+    atlas.active_username = None
+    dialog._apply_active_user_state("", "Guest")
+
+    assert dialog.login_username_entry.get_text() == ""
+
+
 def test_use_account_triggers_activation_and_disables_forms():
     atlas = _AtlasStub()
     atlas.list_accounts_result = [


### PR DESCRIPTION
## Summary
- update the account dialog to sync the login username entry with the active user
- clear the login username entry when no user is persisted so the placeholder is shown
- add coverage ensuring the active user update reflects in the login entry

## Testing
- pytest tests/test_account_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68e41d26c38c8322bd98579f1f836af7