### PR TITLE
Highlight login fields after failed sign-in

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -1984,6 +1984,10 @@ class AccountDialog(Gtk.Window):
 
         self._cancel_login_lockout_timer()
 
+        # Clear any previous validation errors when starting a new attempt.
+        self._mark_field_valid(self.login_username_entry)
+        self._mark_field_valid(self.login_password_entry)
+
         username = (self.login_username_entry.get_text() or "").strip()
         password = self.login_password_entry.get_text() or ""
 
@@ -2023,6 +2027,12 @@ class AccountDialog(Gtk.Window):
             self.close()
         else:
             self.login_feedback_label.set_text("Invalid username or password.")
+            self._mark_field_invalid(self.login_username_entry)
+            self._mark_field_invalid(self.login_password_entry)
+            try:
+                self.login_password_entry.grab_focus()
+            except Exception:  # pragma: no cover - grab_focus may be unavailable in stubs
+                pass
         return False
 
     def _handle_login_error(self, exc: Exception) -> bool:

--- a/tests/test_account_dialog.py
+++ b/tests/test_account_dialog.py
@@ -508,6 +508,18 @@ def test_login_failure_displays_error():
 
     assert dialog.login_feedback_label.get_text() == "Invalid username or password."
     assert not getattr(dialog, "closed", False)
+    assert dialog.login_username_entry.has_css_class("error")
+    assert dialog.login_password_entry.has_css_class("error")
+
+    atlas.login_result = True
+    dialog.login_password_entry.set_text("good-password")
+
+    dialog._on_login_clicked(dialog.login_button)
+
+    assert not dialog.login_username_entry.has_css_class("error")
+    assert not dialog.login_password_entry.has_css_class("error")
+
+    _drain_background(atlas)
 
 
 def test_login_lockout_error_displays_message():


### PR DESCRIPTION
## Summary
- highlight the login username and password entries when authentication fails
- reset login validation styling when a new sign-in attempt starts
- extend the account dialog tests to cover error styling and clearing on retry

## Testing
- pytest tests/test_account_dialog.py -k login_failure_displays_error

------
https://chatgpt.com/codex/tasks/task_e_68e42c9c2cb08322875cf4293b83607d