### PR TITLE
Ensure password symbols exclude whitespace

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -1534,7 +1534,9 @@ class AccountDialog(Gtk.Window):
             missing.append("add an uppercase letter")
         if requirements.require_digit and not any(char.isdigit() for char in password):
             missing.append("add a number")
-        if requirements.require_symbol and not any(not char.isalnum() for char in password):
+        if requirements.require_symbol and not any(
+            (not char.isalnum()) and (not char.isspace()) for char in password
+        ):
             missing.append("add a symbol")
 
         if len(password) < requirements.min_length:
@@ -1552,7 +1554,9 @@ class AccountDialog(Gtk.Window):
                 any(char.islower() for char in password),
                 any(char.isupper() for char in password),
                 any(char.isdigit() for char in password),
-                any(not char.isalnum() for char in password),
+                any(
+                    (not char.isalnum()) and (not char.isspace()) for char in password
+                ),
             )
             if check
         )
@@ -2157,7 +2161,9 @@ class AccountDialog(Gtk.Window):
         if requirements.require_digit and not any(char.isdigit() for char in password):
             return "Password must include a number."
 
-        if requirements.require_symbol and not any(not char.isalnum() for char in password):
+        if requirements.require_symbol and not any(
+            (not char.isalnum()) and (not char.isspace()) for char in password
+        ):
             return "Password must include a symbol such as ! or #."
 
         return None

--- a/modules/user_accounts/user_account_service.py
+++ b/modules/user_accounts/user_account_service.py
@@ -408,7 +408,9 @@ class UserAccountService:
             self.logger.error("Password missing numeric character.")
             raise ValueError(error_message)
 
-        if requirements.require_symbol and not any(not ch.isalnum() for ch in password):
+        if requirements.require_symbol and not any(
+            (not ch.isalnum()) and (not ch.isspace()) for ch in password
+        ):
             self.logger.error("Password missing symbol character.")
             raise ValueError(error_message)
 

--- a/tests/test_account_dialog.py
+++ b/tests/test_account_dialog.py
@@ -306,6 +306,47 @@ def test_password_requirements_refresh_updates_labels():
     assert refreshed_tooltip != initial_tooltip
 
 
+def test_password_strength_requires_non_whitespace_symbol():
+    atlas = _AtlasStub()
+    atlas.set_password_requirements(
+        PasswordRequirements(
+            min_length=10,
+            require_uppercase=True,
+            require_lowercase=True,
+            require_digit=True,
+            require_symbol=True,
+            forbid_whitespace=False,
+        )
+    )
+    dialog = AccountDialog(atlas)
+    if atlas.last_factory is not None:
+        _drain_background(atlas)
+
+    description = dialog._describe_password_strength("Password12 ")
+    assert "add a symbol" in description
+    assert "remove spaces" not in description
+
+
+def test_password_validation_error_requires_non_whitespace_symbol():
+    atlas = _AtlasStub()
+    atlas.set_password_requirements(
+        PasswordRequirements(
+            min_length=10,
+            require_uppercase=True,
+            require_lowercase=True,
+            require_digit=True,
+            require_symbol=True,
+            forbid_whitespace=False,
+        )
+    )
+    dialog = AccountDialog(atlas)
+    if atlas.last_factory is not None:
+        _drain_background(atlas)
+
+    error = dialog._password_validation_error("Password12 ")
+    assert error == "Password must include a symbol such as ! or #."
+
+
 def test_password_toggle_icon_press_updates_state_and_label():
     atlas = _AtlasStub()
     dialog = AccountDialog(atlas)

--- a/tests/test_user_account_service.py
+++ b/tests/test_user_account_service.py
@@ -326,6 +326,21 @@ def test_register_user_rejects_weak_password(tmp_path, monkeypatch):
         service.close()
 
 
+def test_register_user_rejects_whitespace_symbol(tmp_path, monkeypatch):
+    overrides = {'ACCOUNT_PASSWORD_FORBID_WHITESPACE': False}
+    service, _ = _create_service(tmp_path, monkeypatch, config_overrides=overrides)
+
+    try:
+        with pytest.raises(ValueError, match='Passwords must'):
+            service.register_user('spacey', 'Password12 ', 'spacey@example.com')
+
+        error_messages = [args[0] for args, _kwargs in service.logger.errors]
+        assert any('Password missing symbol character' in message for message in error_messages)
+        assert service.list_users() == []
+    finally:
+        service.close()
+
+
 def test_password_requirements_reporting(tmp_path, monkeypatch):
     service, _ = _create_service(tmp_path, monkeypatch)
 


### PR DESCRIPTION
## Summary
- tighten the password symbol requirement to ignore whitespace in the user account service
- mirror the refined symbol checks and password messaging in the account dialog UI
- add backend and UI tests to cover passwords that only use whitespace as a symbol

## Testing
- pytest tests/test_user_account_service.py tests/test_account_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68e431c5a6948322a966e3af1bf913d1