### PR TITLE
Prefer OS user data directories for user accounts

### DIFF
--- a/modules/user_accounts/user_data_manager.py
+++ b/modules/user_accounts/user_data_manager.py
@@ -1,9 +1,11 @@
 # modules/user_accounts/user_data_manager.py
 
-import re
 import json
+import os
 import platform
+import re
 import subprocess
+import tempfile
 from pathlib import Path
 from threading import Lock
 from typing import Optional
@@ -167,32 +169,75 @@ class UserDataManager:
 
     def _determine_base_directory(self, override_dir: Optional[str]) -> Path:
         if override_dir is not None:
-            self.logger.debug(
-                "Using provided base directory for user data: %s",
-                override_dir,
+            override_path = Path(override_dir).expanduser().resolve()
+            ensured = self._ensure_writable_directory(override_path)
+            if ensured:
+                self.logger.debug(
+                    "Using provided base directory for user data: %s",
+                    ensured,
+                )
+                return ensured
+            self.logger.warning(
+                "Provided base directory for user data is not writable: %s",
+                override_path,
             )
-            return Path(override_dir).expanduser().resolve()
+
+        if _user_data_dir:
+            os_data_dir = Path(_user_data_dir("ATLAS", "ATLAS"))
+            ensured = self._ensure_writable_directory(os_data_dir)
+            if ensured:
+                self.logger.debug(
+                    "Using OS user data directory for user data: %s",
+                    ensured,
+                )
+                return ensured
+            self.logger.warning(
+                "OS user data directory for user data is not writable: %s",
+                os_data_dir,
+            )
 
         app_root = self._get_app_root()
         if app_root:
             resolved = Path(app_root).expanduser().resolve() / 'modules' / 'user_accounts'
-            self.logger.debug("Using app root directory for user data: %s", resolved)
-            return resolved
-
-        if _user_data_dir:
-            fallback_base = Path(_user_data_dir("ATLAS", "ATLAS"))
-            self.logger.debug(
-                "Using OS user data directory for user data: %s",
-                fallback_base,
+            ensured = self._ensure_writable_directory(resolved)
+            if ensured:
+                self.logger.debug("Using app root directory for user data: %s", ensured)
+                return ensured
+            self.logger.warning(
+                "App root directory for user data is not writable: %s",
+                resolved,
             )
-        else:  # pragma: no cover - only used when helpers unavailable
-            fallback_base = Path.home() / '.atlas'
+
+        fallback_base = Path.home() / '.atlas'
+        ensured = self._ensure_writable_directory(fallback_base)
+        if ensured:
             self.logger.debug(
                 "Falling back to home directory for user data: %s",
-                fallback_base,
+                ensured,
             )
+            return ensured
 
-        return fallback_base
+        raise RuntimeError("No writable base directory available for user data")
+
+    def _ensure_writable_directory(self, path: Path) -> Optional[Path]:
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            self.logger.warning("Failed to create base directory %s: %s", path, exc)
+            return None
+
+        try:
+            fd, tmp_path = tempfile.mkstemp(dir=str(path))
+        except OSError as exc:
+            self.logger.warning("Base directory %s is not writable: %s", path, exc)
+            return None
+        else:
+            os.close(fd)
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                self.logger.debug("Failed to remove temporary test file: %s", tmp_path)
+            return path
 
     def _get_app_root(self) -> Optional[str]:
         get_app_root = getattr(self.config_manager, 'get_app_root', None)


### PR DESCRIPTION
## Summary
- ensure the user account database and data manager verify overrides are writable and fall back to the OS user-data directory when possible
- add a writable-directory helper used by both components before falling back to the app root and home directory
- cover the new selection flow with tests that simulate an unwritable app root

## Testing
- pytest tests/test_user_account_db.py::test_base_directory_prefers_os_user_data_dir_when_app_root_unwritable tests/test_user_data_manager.py::test_base_directory_prefers_os_user_data_dir_when_app_root_unwritable

------
https://chatgpt.com/codex/tasks/task_e_68e43b4a12ac83228d8485c7daca619e