### PR TITLE
Allow authenticating with email addresses

### DIFF
--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -1580,12 +1580,12 @@ class AccountDialog(Gtk.Window):
         grid = Gtk.Grid(column_spacing=8, row_spacing=8)
         wrapper.append(grid)
 
-        username_label = Gtk.Label(label="Username")
+        username_label = Gtk.Label(label="Username or email")
         username_label.set_xalign(0.0)
         grid.attach(username_label, 0, 0, 1, 1)
 
         self.login_username_entry = Gtk.Entry()
-        self.login_username_entry.set_placeholder_text("Your username")
+        self.login_username_entry.set_placeholder_text("Your username or email")
         grid.attach(self.login_username_entry, 1, 0, 1, 1)
 
         password_label = Gtk.Label(label="Password")
@@ -1996,7 +1996,7 @@ class AccountDialog(Gtk.Window):
         password = self.login_password_entry.get_text() or ""
 
         if not username or not password:
-            self.login_feedback_label.set_text("Username and password are required.")
+            self.login_feedback_label.set_text("Username or email and password are required.")
             return
 
         self._set_login_busy(True, "Signing in…")
@@ -2030,7 +2030,7 @@ class AccountDialog(Gtk.Window):
             self.login_feedback_label.set_text("Signed in successfully.")
             self.close()
         else:
-            self.login_feedback_label.set_text("Invalid username or password.")
+            self.login_feedback_label.set_text("Invalid username/email or password.")
             self._mark_field_invalid(self.login_username_entry)
             self._mark_field_invalid(self.login_password_entry)
             try:

--- a/modules/user_accounts/user_account_db.py
+++ b/modules/user_accounts/user_account_db.py
@@ -436,6 +436,28 @@ class UserAccountDatabase:
             finally:
                 cursor.close()
 
+    def get_username_for_email(self, email: str) -> Optional[str]:
+        """Return the username associated with the given e-mail address."""
+
+        canonical_email = self._canonicalize_email(email)
+        if not canonical_email:
+            return None
+
+        query = "SELECT username FROM user_accounts WHERE email = ?"
+        with self._lock:
+            cursor = self.conn.cursor()
+            try:
+                cursor.execute(query, (canonical_email,))
+                row = cursor.fetchone()
+            finally:
+                cursor.close()
+
+        if not row:
+            return None
+
+        username = row[0]
+        return str(username).strip() or None
+
     def get_all_users(self):
         query = "SELECT * FROM user_accounts"
         with self._lock:

--- a/modules/user_accounts/user_account_service.py
+++ b/modules/user_accounts/user_account_service.py
@@ -483,11 +483,22 @@ class UserAccountService:
     def authenticate_user(self, username: str, password: str) -> bool:
         """Return ``True`` when supplied credentials are valid."""
 
-        normalised_username = self._normalise_username(username)
-        if not normalised_username:
+        identifier = self._normalise_username(username)
+        if not identifier:
             return False
 
         if password is None:
+            return False
+
+        lookup_username = identifier
+        if self._EMAIL_PATTERN.fullmatch(identifier):
+            resolved_username = self._database.get_username_for_email(identifier)
+            if not resolved_username:
+                return False
+            lookup_username = resolved_username
+
+        normalised_username = self._normalise_username(lookup_username)
+        if not normalised_username:
             return False
 
         timestamp: Optional[str] = None

--- a/tests/test_account_dialog.py
+++ b/tests/test_account_dialog.py
@@ -547,7 +547,7 @@ def test_login_failure_displays_error():
     dialog._on_login_clicked(dialog.login_button)
     _drain_background(atlas)
 
-    assert dialog.login_feedback_label.get_text() == "Invalid username or password."
+    assert dialog.login_feedback_label.get_text() == "Invalid username/email or password."
     assert not getattr(dialog, "closed", False)
     assert dialog.login_username_entry.has_css_class("error")
     assert dialog.login_password_entry.has_css_class("error")

--- a/tests/test_user_account_db.py
+++ b/tests/test_user_account_db.py
@@ -239,6 +239,19 @@ def test_update_user_refreshes_profile_on_email_change(tmp_path, monkeypatch):
         db.close_connection()
 
 
+def test_get_username_for_email_is_case_insensitive(tmp_path, monkeypatch):
+    db = _create_db(tmp_path, monkeypatch)
+
+    try:
+        db.add_user('gina', 'Password1!', 'gina@example.com', 'Gina', '1993-04-05')
+
+        assert db.get_username_for_email('gina@example.com') == 'gina'
+        assert db.get_username_for_email('GINA@EXAMPLE.COM') == 'gina'
+        assert db.get_username_for_email('unknown@example.com') is None
+    finally:
+        db.close_connection()
+
+
 def test_update_user_preserves_extra_profile_fields(tmp_path, monkeypatch):
     db = _create_db(tmp_path, monkeypatch)
 
@@ -344,6 +357,7 @@ def test_database_uses_app_root_directory(tmp_path, monkeypatch):
 
     logger = _StubLogger()
     monkeypatch.setattr(user_account_db, 'setup_logger', lambda *_args, **_kwargs: logger)
+    monkeypatch.setattr(user_account_db, '_user_data_dir', None)
 
     db = user_account_db.UserAccountDatabase(db_name='app_root.db')
 
@@ -362,6 +376,7 @@ def test_database_migrates_from_legacy_location(tmp_path, monkeypatch):
 
     logger = _StubLogger()
     monkeypatch.setattr(user_account_db, 'setup_logger', lambda *_args, **_kwargs: logger)
+    monkeypatch.setattr(user_account_db, '_user_data_dir', None)
 
     legacy_dir = tmp_path / 'legacy'
     legacy_dir.mkdir()

--- a/tests/test_user_account_service.py
+++ b/tests/test_user_account_service.py
@@ -431,6 +431,24 @@ def test_authenticate_user_success_and_failure(tmp_path, monkeypatch):
         service.close()
 
 
+def test_authenticate_user_with_email_identifier(tmp_path, monkeypatch):
+    service, _ = _create_service(tmp_path, monkeypatch)
+
+    try:
+        service.register_user('carol', 'Secure123!', 'carol@example.com')
+
+        assert service.authenticate_user('carol@example.com', 'Secure123!') is True
+        assert service.authenticate_user('CAROL@EXAMPLE.COM', 'Secure123!') is True
+
+        record = service._database.get_user('carol')
+        assert record[6] is not None
+
+        assert service.authenticate_user('carol@example.com', 'wrong') is False
+        assert service.authenticate_user('unknown@example.com', 'Secure123!') is False
+    finally:
+        service.close()
+
+
 class _TestClock:
     def __init__(self, start: Optional[_dt.datetime] = None):
         self._now = start or _dt.datetime(2024, 1, 1, tzinfo=_dt.timezone.utc)


### PR DESCRIPTION
## Summary
- allow the account service to resolve email identifiers to usernames before verifying credentials
- update the GTK login form copy to reflect username or email input and adjusted validation feedback
- add database, service, and dialog tests covering email-based authentication workflows

## Testing
- pytest tests/test_user_account_db.py tests/test_user_account_service.py tests/test_account_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68e43cd739a483229f65ddb9b06b0516