### PR TITLE
Implement password reset workflow

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -373,6 +373,46 @@ class ATLAS:
             self._refresh_active_user_identity()
         return bool(success)
 
+    async def request_password_reset(self, identifier: str) -> Optional[Dict[str, object]]:
+        """Initiate a password reset flow for the supplied identifier."""
+
+        service = self._get_user_account_service()
+        challenge = await run_async_in_thread(
+            service.initiate_password_reset,
+            identifier,
+        )
+        if not challenge:
+            return None
+
+        return {
+            "username": challenge.username,
+            "token": challenge.token,
+            "expires_at": challenge.expires_at_iso(),
+        }
+
+    async def verify_password_reset_token(self, username: str, token: str) -> bool:
+        """Check whether the supplied password reset token remains valid."""
+
+        service = self._get_user_account_service()
+        return await run_async_in_thread(
+            service.verify_password_reset_token,
+            username,
+            token,
+        )
+
+    async def complete_password_reset(
+        self, username: str, token: str, new_password: str
+    ) -> bool:
+        """Finish the password reset process by storing a new password."""
+
+        service = self._get_user_account_service()
+        return await run_async_in_thread(
+            service.complete_password_reset,
+            username,
+            token,
+            new_password,
+        )
+
     async def logout_active_user(self) -> None:
         """Clear any active account selection."""
 


### PR DESCRIPTION
## Summary
- add database and service helpers for password reset tokens with configurable expiry
- expose password reset operations through the ATLAS facade and GTK account dialog UI
- cover token issuance, validation, and password updates with new unit tests

## Testing
- pytest tests/test_user_account_service.py tests/test_account_dialog.py tests/test_user_account_db.py

------
https://chatgpt.com/codex/tasks/task_e_68e43f65beac8322aa3a522f6e07d746