### PR TITLE
Enhance account management overview and filtering

### DIFF
--- a/ATLAS/ATLAS.py
+++ b/ATLAS/ATLAS.py
@@ -273,6 +273,12 @@ class ATLAS:
         service = self._get_user_account_service()
         return await run_async_in_thread(service.get_user_details, username)
 
+    async def get_user_account_overview(self) -> Dict[str, object]:
+        """Return aggregated statistics for stored user accounts."""
+
+        service = self._get_user_account_service()
+        return await run_async_in_thread(service.get_user_overview)
+
     async def activate_user_account(self, username: str) -> None:
         """Activate an existing user account without credential prompts."""
 


### PR DESCRIPTION
## Summary
- Add a user account overview API that reports aggregate statistics and expose it through the ATLAS facade.
- Enrich account list metadata with active/locked flags and surface them in the GTK dialog with a summary banner and status filter.
- Extend UI and service unit tests to cover the new filtering behaviour and overview reporting.

## Testing
- pytest tests/test_account_dialog.py
- pytest tests/test_user_account_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e457643dc48322b06dc01d4dd4aa60