### PR TITLE
Use shared AtlasWindow helper for GTK styling

### DIFF
--- a/GTKUI/Chat/chat_page.py
+++ b/GTKUI/Chat/chat_page.py
@@ -25,7 +25,7 @@ from gi.repository import Gtk, Gdk, GLib
 import logging
 from logging.handlers import RotatingFileHandler
 
-from GTKUI.Utils.utils import apply_css
+from GTKUI.Utils.styled_window import AtlasWindow
 from GTKUI.Utils.logging import GTKUILogHandler, read_recent_log_lines
 from modules.Tools.tool_event_system import event_system
 
@@ -33,7 +33,7 @@ from modules.Tools.tool_event_system import event_system
 logger = logging.getLogger(__name__)
 
 
-class ChatPage(Gtk.Window):
+class ChatPage(AtlasWindow):
     """
     ChatPage window for user interaction.
 
@@ -49,16 +49,8 @@ class ChatPage(Gtk.Window):
         Args:
             atlas: The main ATLAS application instance.
         """
-        super().__init__()
+        super().__init__(default_size=(700, 520))
         self.ATLAS = atlas
-        self.set_default_size(700, 520)
-
-        # Apply style classes to match the dark theme of the sidebar.
-        self.get_style_context().add_class("chat-page")
-        self.get_style_context().add_class("sidebar")
-
-        # Apply centralized CSS styling.
-        apply_css()
 
         # --- Header bar with persona title & quick actions ---
         self.header_bar = Gtk.HeaderBar()

--- a/GTKUI/Provider_manager/Settings/Anthropic_settings.py
+++ b/GTKUI/Provider_manager/Settings/Anthropic_settings.py
@@ -11,28 +11,26 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib
 
-from GTKUI.Utils.utils import apply_css, create_box
+from GTKUI.Utils.styled_window import AtlasWindow
+from GTKUI.Utils.utils import create_box
 from modules.background_tasks import run_async_in_thread
 
 logger = logging.getLogger(__name__)
 
 
-class AnthropicSettingsWindow(Gtk.Window):
+class AnthropicSettingsWindow(AtlasWindow):
     """Collect Anthropic-specific preferences such as default model and retries."""
 
     def __init__(self, ATLAS, config_manager, parent_window):
-        super().__init__(title="Anthropic Settings")
-        apply_css()
-        style_context = self.get_style_context()
-        style_context.add_class("chat-page")
-        style_context.add_class("sidebar")
+        super().__init__(
+            title="Anthropic Settings",
+            modal=True,
+            transient_for=parent_window,
+            default_size=(480, 360),
+        )
         self.ATLAS = ATLAS
         self.config_manager = config_manager
         self.parent_window = parent_window
-        if parent_window is not None:
-            self.set_transient_for(parent_window)
-        self.set_modal(True)
-        self.set_default_size(480, 360)
 
         self._last_message: Optional[Tuple[str, str, Gtk.MessageType]] = None
 

--- a/GTKUI/Provider_manager/Settings/Google_settings.py
+++ b/GTKUI/Provider_manager/Settings/Google_settings.py
@@ -11,12 +11,13 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib
 
-from GTKUI.Utils.utils import apply_css, create_box
+from GTKUI.Utils.styled_window import AtlasWindow
+from GTKUI.Utils.utils import create_box
 
 logger = logging.getLogger(__name__)
 
 
-class GoogleSettingsWindow(Gtk.Window):
+class GoogleSettingsWindow(AtlasWindow):
     """Collect Google Gemini defaults such as model selection and safety filters."""
 
     _SAFETY_CATEGORIES: Tuple[Tuple[str, str], ...] = (
@@ -49,18 +50,15 @@ class GoogleSettingsWindow(Gtk.Window):
     )
 
     def __init__(self, ATLAS, config_manager, parent_window):
-        super().__init__(title="Google Settings")
-        apply_css()
-        style_context = self.get_style_context()
-        style_context.add_class("chat-page")
-        style_context.add_class("sidebar")
+        super().__init__(
+            title="Google Settings",
+            modal=True,
+            transient_for=parent_window,
+            default_size=(420, 520),
+        )
         self.ATLAS = ATLAS
         self.config_manager = config_manager
         self.parent_window = parent_window
-        if parent_window is not None:
-            self.set_transient_for(parent_window)
-        self.set_modal(True)
-        self.set_default_size(420, 520)
 
         self._api_key_visible = False
         self._defaults: Dict[str, Any] = {

--- a/GTKUI/Provider_manager/Settings/HF_settings.py
+++ b/GTKUI/Provider_manager/Settings/HF_settings.py
@@ -19,13 +19,14 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, Gdk, GLib
 
-from GTKUI.Utils.utils import apply_css, create_box
+from GTKUI.Utils.styled_window import AtlasWindow
+from GTKUI.Utils.utils import create_box
 
 
 logger = logging.getLogger(__name__)
 
 
-class HuggingFaceSettingsWindow(Gtk.Window):
+class HuggingFaceSettingsWindow(AtlasWindow):
     def __init__(self, ATLAS, config_manager, parent_window):
         """
         Initialize the HuggingFaceSettingsWindow.
@@ -35,16 +36,13 @@ class HuggingFaceSettingsWindow(Gtk.Window):
             config_manager: The configuration manager instance.
             parent_window: The parent GTK window.
         """
-        super().__init__(title="HuggingFace Settings")
-        apply_css()
-        style_context = self.get_style_context()
-        style_context.add_class("chat-page")
-        style_context.add_class("sidebar")
+        super().__init__(
+            title="HuggingFace Settings",
+            modal=True,
+            transient_for=parent_window,
+            default_size=(800, 600),
+        )
         self.parent_window = parent_window
-        self.set_transient_for(parent_window)
-        self.set_modal(True)
-        
-        self.set_default_size(800, 600)
         self.ATLAS = ATLAS
         self.config_manager = config_manager
 

--- a/GTKUI/Provider_manager/Settings/Mistral_settings.py
+++ b/GTKUI/Provider_manager/Settings/Mistral_settings.py
@@ -14,29 +14,26 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import GLib, Gtk
 
-from GTKUI.Utils.utils import apply_css, create_box
+from GTKUI.Utils.styled_window import AtlasWindow
+from GTKUI.Utils.utils import create_box
 from modules.background_tasks import run_async_in_thread
 
 logger = logging.getLogger(__name__)
 
 
-class MistralSettingsWindow(Gtk.Window):
+class MistralSettingsWindow(AtlasWindow):
     """Collect and persist preferences specific to the Mistral chat provider."""
 
     def __init__(self, ATLAS, config_manager, parent_window):
-        super().__init__(title="Mistral Settings")
-        apply_css()
-        style_context = self.get_style_context()
-        style_context.add_class("chat-page")
-        style_context.add_class("sidebar")
-
+        super().__init__(
+            title="Mistral Settings",
+            modal=True,
+            transient_for=parent_window,
+            default_size=(420, 360),
+        )
         self.ATLAS = ATLAS
         self.config_manager = config_manager
         self.parent_window = parent_window
-        if parent_window is not None:
-            self.set_transient_for(parent_window)
-        self.set_modal(True)
-        self.set_default_size(420, 360)
 
         self._last_message: Optional[Tuple[str, str, Gtk.MessageType]] = None
         self._current_settings: Dict[str, Any] = {}

--- a/GTKUI/Provider_manager/Settings/OA_settings.py
+++ b/GTKUI/Provider_manager/Settings/OA_settings.py
@@ -12,28 +12,26 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib
 
-from GTKUI.Utils.utils import apply_css, create_box
+from GTKUI.Utils.styled_window import AtlasWindow
+from GTKUI.Utils.utils import create_box
 from modules.background_tasks import run_async_in_thread
 
 logger = logging.getLogger(__name__)
 
 
-class OpenAISettingsWindow(Gtk.Window):
+class OpenAISettingsWindow(AtlasWindow):
     """Collect OpenAI-specific preferences such as default model and streaming mode."""
 
     def __init__(self, ATLAS, config_manager, parent_window):
-        super().__init__(title="OpenAI Settings")
-        apply_css()
-        style_context = self.get_style_context()
-        style_context.add_class("chat-page")
-        style_context.add_class("sidebar")
+        super().__init__(
+            title="OpenAI Settings",
+            modal=True,
+            transient_for=parent_window,
+            default_size=(460, 360),
+        )
         self.ATLAS = ATLAS
         self.config_manager = config_manager
         self.parent_window = parent_window
-        if parent_window is not None:
-            self.set_transient_for(parent_window)
-        self.set_modal(True)
-        self.set_default_size(460, 360)
 
         self._last_message: Optional[Tuple[str, str, Gtk.MessageType]] = None
         self._stored_base_url: Optional[str] = None

--- a/GTKUI/Provider_manager/provider_management.py
+++ b/GTKUI/Provider_manager/provider_management.py
@@ -8,6 +8,7 @@ from gi.repository import Gtk, Gdk, GLib
 import os
 import logging
 
+from GTKUI.Utils.styled_window import AtlasWindow
 from GTKUI.Utils.utils import apply_css, create_box
 from .Settings.HF_settings import HuggingFaceSettingsWindow
 from .Settings.OA_settings import OpenAISettingsWindow
@@ -68,16 +69,13 @@ class ProviderManagement:
         Displays the provider selection window, listing all available providers.
         Each provider is displayed with a label and a settings icon.
         """
-        self.provider_window = Gtk.Window(title="Select Provider")
-        self.provider_window.set_default_size(300, 400)
-        self.provider_window.set_transient_for(self.parent_window)
-        self.provider_window.set_modal(True)
+        self.provider_window = AtlasWindow(
+            title="Select Provider",
+            default_size=(300, 400),
+            modal=True,
+            transient_for=self.parent_window,
+        )
         self.provider_window.set_tooltip_text("Choose a default LLM provider or open its settings.")
-
-        apply_css()
-        style_context = self.provider_window.get_style_context()
-        style_context.add_class("chat-page")
-        style_context.add_class("sidebar")
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -245,16 +243,13 @@ class ProviderManagement:
         Displays the settings window for a specific provider, including an API key entry
         with a visibility toggle (eye).
         """
-        settings_window = Gtk.Window(title=f"Settings for {provider_name}")
-        settings_window.set_default_size(400, 300)
-        settings_window.set_transient_for(self.parent_window)
-        settings_window.set_modal(True)
+        settings_window = AtlasWindow(
+            title=f"Settings for {provider_name}",
+            default_size=(400, 300),
+            modal=True,
+            transient_for=self.parent_window,
+        )
         settings_window.set_tooltip_text(f"Update API key and settings for {provider_name}.")
-
-        apply_css()
-        style_context = settings_window.get_style_context()
-        style_context.add_class("chat-page")
-        style_context.add_class("sidebar")
 
         main_vbox = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=10, margin=10)
         settings_window.set_child(main_vbox)

--- a/GTKUI/Settings/Speech/speech_settings.py
+++ b/GTKUI/Settings/Speech/speech_settings.py
@@ -24,10 +24,11 @@ import os
 import logging
 from typing import Any, Dict, List, Optional
 
+from GTKUI.Utils.styled_window import AtlasWindow
 from GTKUI.Utils.utils import apply_css
 logger = logging.getLogger(__name__)
 
-class SpeechSettings(Gtk.Window):
+class SpeechSettings(AtlasWindow):
     def __init__(self, atlas):
         """
         Initializes the Speech Settings window with a tabbed interface.
@@ -35,19 +36,14 @@ class SpeechSettings(Gtk.Window):
         Args:
             atlas: The main ATLAS application instance.
         """
-        super().__init__(title="Speech Settings")
+        super().__init__(title="Speech Settings", default_size=(500, 800))
         self.ATLAS = atlas
 
         # Paths for custom eye icons (fallbacks to themed symbolic icons if not found)
         self._eye_icon_path = self._abs_icon("../../Icons/eye.png")
         self._eye_off_icon_path = self._abs_icon("../../Icons/eye-off.png")
 
-        # Apply global CSS styling.
-        self.get_style_context().add_class("chat-page")
-        self.get_style_context().add_class("sidebar")
-        apply_css()
-
-        self.set_default_size(500, 800)
+        # Apply global CSS styling via AtlasWindow base class.
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
         vbox.set_margin_top(10)
         vbox.set_margin_bottom(10)

--- a/GTKUI/UserAccounts/account_dialog.py
+++ b/GTKUI/UserAccounts/account_dialog.py
@@ -18,6 +18,7 @@ try:  # pragma: no cover - Gio may be unavailable in some environments
 except Exception:  # pragma: no cover - fall back gracefully when Gio is missing
     Gio = None  # type: ignore[assignment]
 
+from GTKUI.Utils.styled_window import AtlasWindow
 from GTKUI.Utils.utils import apply_css, create_box
 from modules.user_accounts.user_account_service import (
     AccountLockedError,
@@ -27,7 +28,7 @@ from modules.user_accounts.user_account_service import (
 )
 
 
-class AccountDialog(Gtk.Window):
+class AccountDialog(AtlasWindow):
     """Provide login, registration, and logout flows for ATLAS accounts."""
 
     _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
@@ -37,7 +38,12 @@ class AccountDialog(Gtk.Window):
     _STALE_ACCOUNT_THRESHOLD_DAYS = 90
 
     def __init__(self, atlas, parent: Optional[Gtk.Window] = None) -> None:
-        super().__init__(title="Account Management")
+        super().__init__(
+            title="Account Management",
+            modal=True,
+            transient_for=parent,
+            default_size=(420, 420),
+        )
         self.logger = logging.getLogger(__name__)
         self.ATLAS = atlas
         self._active_user_listener = None
@@ -73,20 +79,6 @@ class AccountDialog(Gtk.Window):
         self._last_password_reset_message: Optional[str] = None
         self._account_summary: dict[str, object] = {}
         self._last_account_context: str = "list"
-
-        self.set_modal(True)
-        if parent is not None:
-            try:
-                self.set_transient_for(parent)
-            except Exception:  # pragma: no cover - defensive for stub environments
-                pass
-
-        self.set_default_size(420, 420)
-
-        apply_css()
-        context = self.get_style_context()
-        context.add_class("chat-page")
-        context.add_class("sidebar")
 
         self._build_ui()
         self._initialise_password_requirements()

--- a/GTKUI/Utils/styled_window.py
+++ b/GTKUI/Utils/styled_window.py
@@ -1,0 +1,103 @@
+"""Shared GTK window helper for ATLAS UI components."""
+
+from __future__ import annotations
+
+from typing import Sequence
+from types import MethodType
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+
+from .utils import apply_css
+
+
+class AtlasWindow(Gtk.Window):
+    """GTK window base class that applies the ATLAS shared styling."""
+
+    def __init__(
+        self,
+        *,
+        title: str | None = None,
+        default_size: tuple[int, int] | None = None,
+        modal: bool | None = None,
+        transient_for: Gtk.Window | None = None,
+        css_classes: Sequence[str] | None = None,
+        apply_styles: bool = True,
+    ) -> None:
+        super().__init__(title=title)
+
+        if default_size is not None:
+            try:
+                self.set_default_size(*default_size)
+            except Exception:  # pragma: no cover - defensive for stub environments
+                pass
+
+        if modal is not None:
+            try:
+                self.set_modal(modal)
+            except Exception:  # pragma: no cover - defensive for stub environments
+                pass
+
+        if transient_for is not None:
+            try:
+                self.set_transient_for(transient_for)
+            except Exception:  # pragma: no cover
+                pass
+
+        if apply_styles:
+            try:
+                apply_css()
+            except Exception:  # pragma: no cover - styling is best-effort in tests
+                pass
+
+        self._apply_style_classes(css_classes)
+        self._ensure_set_child()
+        self._ensure_signal_support()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _apply_style_classes(self, css_classes: Sequence[str] | None) -> None:
+        context = getattr(self, "get_style_context", lambda: None)()
+        if context is None:
+            return
+
+        for class_name in ("chat-page", "sidebar"):
+            try:
+                context.add_class(class_name)
+            except Exception:  # pragma: no cover - GTK stubs in unit tests
+                continue
+
+        if css_classes is None:
+            return
+
+        for class_name in css_classes:
+            try:
+                context.add_class(class_name)
+            except Exception:  # pragma: no cover
+                continue
+
+    def _ensure_set_child(self) -> None:
+        if hasattr(self, "set_child"):
+            return
+
+        def _set_child_fallback(_self, child):
+            setattr(_self, "_fallback_child", child)
+
+        setattr(self, "set_child", MethodType(_set_child_fallback, self))
+
+    def _ensure_signal_support(self) -> None:
+        if not hasattr(self, "_signal_handlers"):
+            setattr(self, "_signal_handlers", {})
+
+        if hasattr(self, "connect"):
+            return
+
+        def _connect_fallback(_self, signal_name, callback, *args):
+            handlers = _self._signal_handlers.setdefault(signal_name, [])
+            handlers.append((callback, args))
+            return len(handlers) - 1
+
+        setattr(self, "connect", MethodType(_connect_fallback, self))

--- a/GTKUI/sidebar.py
+++ b/GTKUI/sidebar.py
@@ -22,11 +22,12 @@ from GTKUI.Chat.chat_page import ChatPage
 from GTKUI.Persona_manager.persona_management import PersonaManagement
 from GTKUI.Provider_manager.provider_management import ProviderManagement
 from GTKUI.UserAccounts.account_dialog import AccountDialog
-from GTKUI.Utils.utils import apply_css, create_box
+from GTKUI.Utils.styled_window import AtlasWindow
+from GTKUI.Utils.utils import create_box
 
 logger = logging.getLogger(__name__)
 
-class Sidebar(Gtk.Window):
+class Sidebar(AtlasWindow):
     def __init__(self, atlas):
         """
         Initializes the Sidebar window.
@@ -34,7 +35,7 @@ class Sidebar(Gtk.Window):
         Args:
             atlas: The main ATLAS application instance.
         """
-        super().__init__(title="Sidebar")
+        super().__init__(title="Sidebar", default_size=(80, 600))
         self.ATLAS = atlas
         self.persona_management = PersonaManagement(self.ATLAS, self)
         self.provider_management = ProviderManagement(self.ATLAS, self)
@@ -42,10 +43,7 @@ class Sidebar(Gtk.Window):
         self._account_dialog = None
 
         # Set default window size and style.
-        self.set_default_size(80, 600)
         self.set_decorated(False)
-        self.get_style_context().add_class("sidebar")
-        apply_css()
 
         # Create the main container box.
         self.box = create_box(orientation=Gtk.Orientation.VERTICAL, spacing=5, margin=10)

--- a/tests/test_account_dialog.py
+++ b/tests/test_account_dialog.py
@@ -215,6 +215,7 @@ class _AtlasStub:
 
 @pytest.fixture(autouse=True)
 def disable_css(monkeypatch):
+    monkeypatch.setattr("GTKUI.Utils.styled_window.apply_css", lambda: None)
     monkeypatch.setattr("GTKUI.UserAccounts.account_dialog.apply_css", lambda: None)
 
 

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -3398,9 +3398,7 @@ def test_anthropic_settings_window_dispatches_updates(provider_manager):
 
 def test_mistral_settings_window_round_trips_defaults(provider_manager, monkeypatch):
     monkeypatch.setattr("GTKUI.Utils.utils.apply_css", lambda: None)
-    monkeypatch.setattr(
-        "GTKUI.Provider_manager.Settings.Mistral_settings.apply_css", lambda: None
-    )
+    monkeypatch.setattr("GTKUI.Utils.styled_window.apply_css", lambda: None)
     monkeypatch.setattr(
         Gtk.Window,
         "get_style_context",
@@ -3636,9 +3634,7 @@ def test_mistral_settings_window_round_trips_defaults(provider_manager, monkeypa
 
 def test_mistral_settings_window_saves_api_key(provider_manager, monkeypatch):
     monkeypatch.setattr("GTKUI.Utils.utils.apply_css", lambda: None)
-    monkeypatch.setattr(
-        "GTKUI.Provider_manager.Settings.Mistral_settings.apply_css", lambda: None
-    )
+    monkeypatch.setattr("GTKUI.Utils.styled_window.apply_css", lambda: None)
     monkeypatch.setattr(
         Gtk.Window,
         "get_style_context",
@@ -3706,9 +3702,7 @@ def test_mistral_settings_window_saves_api_key_with_fallback(
     provider_manager, monkeypatch
 ):
     monkeypatch.setattr("GTKUI.Utils.utils.apply_css", lambda: None)
-    monkeypatch.setattr(
-        "GTKUI.Provider_manager.Settings.Mistral_settings.apply_css", lambda: None
-    )
+    monkeypatch.setattr("GTKUI.Utils.styled_window.apply_css", lambda: None)
     monkeypatch.setattr(
         Gtk.Window,
         "get_style_context",
@@ -3768,9 +3762,7 @@ def test_mistral_settings_window_refresh_requires_api_key(
     provider_manager, monkeypatch
 ):
     monkeypatch.setattr("GTKUI.Utils.utils.apply_css", lambda: None)
-    monkeypatch.setattr(
-        "GTKUI.Provider_manager.Settings.Mistral_settings.apply_css", lambda: None
-    )
+    monkeypatch.setattr("GTKUI.Utils.styled_window.apply_css", lambda: None)
     monkeypatch.setattr(
         Gtk.Window,
         "get_style_context",
@@ -3805,9 +3797,7 @@ def test_mistral_settings_window_refresh_requires_api_key(
 
 def test_mistral_settings_window_refresh_updates_models(provider_manager, monkeypatch):
     monkeypatch.setattr("GTKUI.Utils.utils.apply_css", lambda: None)
-    monkeypatch.setattr(
-        "GTKUI.Provider_manager.Settings.Mistral_settings.apply_css", lambda: None
-    )
+    monkeypatch.setattr("GTKUI.Utils.styled_window.apply_css", lambda: None)
     monkeypatch.setattr(
         Gtk.Window,
         "get_style_context",
@@ -3878,9 +3868,7 @@ def test_mistral_settings_window_refresh_updates_models(provider_manager, monkey
 
 def test_mistral_settings_window_refresh_handles_error(provider_manager, monkeypatch):
     monkeypatch.setattr("GTKUI.Utils.utils.apply_css", lambda: None)
-    monkeypatch.setattr(
-        "GTKUI.Provider_manager.Settings.Mistral_settings.apply_css", lambda: None
-    )
+    monkeypatch.setattr("GTKUI.Utils.styled_window.apply_css", lambda: None)
     monkeypatch.setattr(
         Gtk.Window,
         "get_style_context",


### PR DESCRIPTION
## Summary
- add an AtlasWindow base class that applies shared CSS styling and provides fallback behaviours for tests
- refactor chat, sidebar, account, speech, and provider settings windows to use the shared helper
- update tests to patch the new helper when disabling CSS

## Testing
- pytest tests/test_account_dialog.py -k close -q
- pytest tests/test_provider_manager.py -k "mistral_settings_window_round_trips_defaults" -q

------
https://chatgpt.com/codex/tasks/task_e_68e51a0314f48322bd5b92f456f19a83