### PR TITLE
Use AtlasWindow for persona info popup

### DIFF
--- a/GTKUI/Persona_manager/General_Tab/general_tab.py
+++ b/GTKUI/Persona_manager/General_Tab/general_tab.py
@@ -6,26 +6,13 @@ import gi
 gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk, Gdk, Pango
 
-from GTKUI.Utils.utils import apply_css
+from GTKUI.Utils.styled_window import AtlasWindow
 
 
-class InfoPopup(Gtk.Window):
+class InfoPopup(AtlasWindow):
     def __init__(self, parent, text):
-        super().__init__(title="")
-        self.set_transient_for(parent)
-        self.set_modal(True)
+        super().__init__(title="", modal=True, transient_for=parent)
         self.set_decorated(False)
-
-        try:
-            apply_css()
-        except (AttributeError, FileNotFoundError, RuntimeError):
-            pass
-        get_style_context = getattr(self, "get_style_context", None)
-        if callable(get_style_context):
-            style_context = get_style_context()
-            if hasattr(style_context, "add_class"):
-                style_context.add_class("chat-page")
-                style_context.add_class("sidebar")
 
         # Create a label with no wrapping
         label = Gtk.Label(label=text)


### PR DESCRIPTION
## Summary
- make the persona general tab info popup inherit from `AtlasWindow`
- let the shared window base handle styling and modal/transient setup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e522a78c188322b341c24f504e2819