### PR TITLE
Fix debug pause button label handling

### DIFF
--- a/GTKUI/Chat/chat_page.py
+++ b/GTKUI/Chat/chat_page.py
@@ -1180,12 +1180,20 @@ class ChatPage(AtlasWindow):
             self.debug_log_buffer.set_text("")
 
     def _on_debug_pause_toggled(self, button: Gtk.ToggleButton):
-        if self._debug_log_handler is None:
-            button.set_active(False)
+        handler = getattr(self, "_debug_log_handler", None)
+        target_btn = getattr(self, "debug_pause_btn", None)
+
+        if handler is None:
+            if button.get_active():
+                button.set_active(False)
+            if isinstance(target_btn, Gtk.ToggleButton):
+                target_btn.set_label("Pause")
             return
+
         paused = button.get_active()
-        self._debug_log_handler.set_paused(paused)
-        self._debug_pause_btn.set_label("Resume" if paused else "Pause")
+        handler.set_paused(paused)
+        if isinstance(target_btn, Gtk.ToggleButton):
+            target_btn.set_label("Resume" if paused else "Pause")
 
     def _on_debug_open_log_clicked(self, *_args):
         path_value = getattr(self, "_debug_log_path", None)


### PR DESCRIPTION
## Summary
- keep the pause toggle label in sync with the stored debug_pause_btn instance
- guard against missing log handlers by resetting the toggle before returning

## Testing
- /usr/bin/python3 /tmp/debug_pause_test.py

------
https://chatgpt.com/codex/tasks/task_e_68e524cd8b0483229b7f5797d74199cb