### PR TITLE
Persist UI debug log retention changes

### DIFF
--- a/ATLAS/config.py
+++ b/ATLAS/config.py
@@ -2589,6 +2589,7 @@ class ConfigManager:
                 normalized = None
 
         if normalized is not None:
+            # Enforce a practical lower bound so the UI handler can operate safely.
             normalized = max(100, normalized)
             self.yaml_config['UI_DEBUG_LOG_MAX_LINES'] = normalized
             self.config['UI_DEBUG_LOG_MAX_LINES'] = normalized


### PR DESCRIPTION
## Summary
- ensure the chat page updates its debug log handler before persisting retention changes and re-syncs any normalized values
- add a config manager helper to normalize and persist the UI debug log line limit to both in-memory and YAML configs

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5275b7fc88322b38f12f56d24eed3