### PR TITLE
Add copy popover and wrap sync to debug log view

### DIFF
--- a/GTKUI/Chat/chat_page.py
+++ b/GTKUI/Chat/chat_page.py
@@ -1001,18 +1001,20 @@ class ChatPage(AtlasWindow):
         self.debug_log_view = Gtk.TextView.new_with_buffer(self.debug_log_buffer)
         self.debug_log_view.set_editable(False)
         self.debug_log_view.set_cursor_visible(False)
-        self.debug_log_view.set_wrap_mode(Gtk.WrapMode.NONE)
+        self.debug_log_view.set_wrap_mode(self._get_terminal_wrap_mode())
         if hasattr(self.debug_log_view, "set_monospace"):
             self.debug_log_view.set_monospace(True)
         self.debug_log_view.add_css_class("monospace")
         self.debug_log_view.set_hexpand(True)
         self.debug_log_view.set_vexpand(True)
+        self._terminal_section_text_views.append(self.debug_log_view)
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_hexpand(True)
         scrolled.set_vexpand(True)
         scrolled.set_child(self.debug_log_view)
+        self._install_terminal_copy_menu(self.debug_log_view, self.debug_log_buffer, self.debug_log_view)
         self.debug_tab_box.append(scrolled)
 
         debug_label = Gtk.Label(label="Debug")


### PR DESCRIPTION
## Summary
- reuse the terminal copy popover helper for the debug log view so it offers the same context menu
- ensure the debug log view participates in the wrap toggle so its wrapping stays in sync with terminal sections

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5342c0fa48322ab82d1f29ec00b8d