### PR TITLE
Fix debug logger focus signal for GTK4

### DIFF
--- a/GTKUI/Chat/chat_page.py
+++ b/GTKUI/Chat/chat_page.py
@@ -975,7 +975,7 @@ class ChatPage(AtlasWindow):
         self.debug_logger_entry.set_text(logger_names_text)
         self.debug_logger_entry.set_tooltip_text("Comma-separated logger names to mirror in the UI debug console")
         self.debug_logger_entry.connect("activate", self._on_debug_logger_names_committed)
-        self.debug_logger_entry.connect("focus-out-event", self._on_debug_logger_names_committed)
+        self.debug_logger_entry.connect("focus-out", self._on_debug_logger_names_committed)
         controls.append(self.debug_logger_entry)
 
         retention_label = Gtk.Label(label="Max lines:")


### PR DESCRIPTION
## Summary
- replace the deprecated `focus-out-event` connection with the GTK4 `focus-out` signal when wiring the debug logger entry
- prevent the UI from raising a TypeError when the entry loses focus

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e539731c508322b065d952631fa343