### PR TITLE
Create notebook-based ATLAS workspace shell

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 
 from ATLAS.ATLAS import ATLAS
-from GTKUI.sidebar import Sidebar
+from GTKUI.sidebar import MainWindow
 
 async def initialize_atlas():
     atlas = ATLAS()
@@ -18,12 +18,12 @@ async def initialize_atlas():
 def main():
     atlas = asyncio.run(initialize_atlas())
 
-    app = Gtk.Application(application_id='com.example.sidebar')
+    app = Gtk.Application(application_id='com.example.atlas')
 
     def on_activate(app):
-        sidebar = Sidebar(atlas)
-        sidebar.set_application(app)
-        sidebar.present()
+        window = MainWindow(atlas)
+        window.set_application(app)
+        window.present()
 
     app.connect('activate', on_activate)
     app.run()


### PR DESCRIPTION
## Summary
- replace the standalone sidebar window with a MainWindow that combines the navigation column and a shared notebook workspace
- adapt chat, provider management, persona management, and speech settings modules to expose embeddable widgets and to cooperate with the shared window
- update the GTK application entry point to present the new main window

## Testing
- pytest tests/test_chat_async_helper.py

------
https://chatgpt.com/codex/tasks/task_e_68e548d16ca88322b4dc73a5051b53a4