### PR TITLE
Add concerns sub-tab to user dialogue workspace

### DIFF
--- a/GTKUI/Utils/style.css
+++ b/GTKUI/Utils/style.css
@@ -271,3 +271,34 @@ tooltip {
     font-size: 12px;
     border: 1px solid #777777;
 }
+
+/* Concerns sub-tab styling */
+.concerns-intro {
+    font-size: 13px;
+    color: #dcdcdc;
+}
+
+.concerns-list {
+    background-color: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 10px;
+}
+
+.concerns-list > row {
+    background-color: transparent;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.concerns-list > row:last-child {
+    border-bottom: none;
+}
+
+.concern-title {
+    font-weight: 600;
+    color: #ffffff;
+}
+
+.concern-preview {
+    color: #bdbdbd;
+    font-size: 13px;
+}


### PR DESCRIPTION
## Summary
- split the chat workspace into a sub-notebook so the dialogue transcript stays independent from additional panes
- add a dedicated concerns tab that aggregates conversation metadata into a readable list and styles it for the dark theme

## Testing
- pytest tests/test_chat_session_thinking.py

------
https://chatgpt.com/codex/tasks/task_e_68e5831dfce083229815b78c6cefe453