### PR TITLE
Fix GTK4 title and dialog compatibility issues in chat UI

### DIFF
--- a/GTKUI/sidebar.py
+++ b/GTKUI/sidebar.py
@@ -263,7 +263,17 @@ class MainWindow(AtlasWindow):
             text="Initialization Error",
         )
         self._apply_shared_styles(dialog)
-        dialog.format_secondary_text(message)
+        # ``Gtk.MessageDialog.format_secondary_text`` was removed in GTK4.
+        # Prefer ``set_secondary_text`` when available and fall back to
+        # directly assigning the property for compatibility with GTK 4.x.
+        set_secondary = getattr(dialog, "set_secondary_text", None)
+        if callable(set_secondary):
+            set_secondary(message)
+        else:
+            try:
+                dialog.props.secondary_text = message
+            except Exception:  # pragma: no cover - property unavailable
+                pass
         dialog.connect("response", lambda d, r: d.destroy())
         dialog.present()
 


### PR DESCRIPTION
## Summary
- update the chat page to set the window title through the root widget when available instead of assuming a set_title method on the page itself
- fix the sidebar error dialog to use GTK4-compatible secondary text handling

## Testing
- pytest *(fails: existing suite requires provider stubs that are not present in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5975c511883228855ba89266a5178