### PR TITLE
Clamp Atlas window size to monitor bounds

### DIFF
--- a/GTKUI/sidebar.py
+++ b/GTKUI/sidebar.py
@@ -28,7 +28,9 @@ class MainWindow(AtlasWindow):
     """Top-level Atlas window with a navigation column and notebook workspace."""
 
     def __init__(self, atlas) -> None:
-        super().__init__(title="ATLAS", default_size=(1200, 800))
+        super().__init__(title="ATLAS")
+        safe_width, safe_height = self._calculate_safe_size(1200, 800)
+        self.set_default_size(safe_width, safe_height)
         self.ATLAS = atlas
         self._pages: Dict[str, Gtk.Widget] = {}
         self._page_controllers: Dict[str, Any] = {}

--- a/tests/test_window_sizing.py
+++ b/tests/test_window_sizing.py
@@ -1,0 +1,38 @@
+"""Unit tests for the AtlasWindow sizing helpers."""
+
+import pytest
+
+try:  # pragma: no cover - skip when GTK bindings are unavailable
+    from GTKUI.Utils.styled_window import AtlasWindow
+except ModuleNotFoundError:  # pragma: no cover - environments without gi
+    AtlasWindow = None
+    pytest.skip("PyGObject is not installed", allow_module_level=True)
+
+
+class _FakeWindow:
+    """Test double that reuses the AtlasWindow sizing helpers."""
+
+    _clamp_dimension = AtlasWindow._clamp_dimension
+    _calculate_safe_size = AtlasWindow._calculate_safe_size
+
+    def __init__(self, monitor_size):
+        self._monitor_size = monitor_size
+
+    def _get_primary_monitor_size(self):
+        return self._monitor_size
+
+
+def test_calculate_safe_size_clamps_to_monitor_bounds():
+    window = _FakeWindow((1400, 900))
+    width, height = window._calculate_safe_size(1600, 1200)
+
+    assert width == 1336  # 1400 - 64 margin
+    assert height == 836  # 900 - 64 margin
+
+
+def test_calculate_safe_size_returns_desired_when_monitor_missing():
+    window = _FakeWindow(None)
+    width, height = window._calculate_safe_size(800, 600)
+
+    assert width == 800
+    assert height == 600


### PR DESCRIPTION
## Summary
- clamp the Atlas window default size to the primary monitor geometry with a safety margin
- ensure MainWindow applies the clamped size on construction and cover the helper logic with tests

## Testing
- pytest tests/test_window_sizing.py

------
https://chatgpt.com/codex/tasks/task_e_68e59e96abb88322abcae98114af8b67