### PR TITLE
Add spacer to navigation sidebar for footer anchoring

### DIFF
--- a/GTKUI/sidebar.py
+++ b/GTKUI/sidebar.py
@@ -367,6 +367,10 @@ class _NavigationSidebar(Gtk.Box):
             container=content_box,
         )
 
+        spacer = Gtk.Box()
+        spacer.set_vexpand(True)
+        content_box.append(spacer)
+
         bottom_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
         bottom_box.set_valign(Gtk.Align.END)
         bottom_box.set_hexpand(True)


### PR DESCRIPTION
## Summary
- add an expanding spacer in the navigation sidebar's scrolled content
- ensure the footer box remains appended after the spacer so it stays anchored when space allows

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e5aa614b2c8322ae321ebb736fd25f